### PR TITLE
feat/154 : 회원가입 API 구현

### DIFF
--- a/server/collusic-be/.gitignore
+++ b/server/collusic-be/.gitignore
@@ -1,10 +1,6 @@
 HELP.md
 target/
-!.mvn/wrapper/maven-wrapper.jar
-!**/src/main/**/target/
-!**/src/test/**/target/
-!**/src/main/resources/application-oauth.properties
-application-oauth.properties
+.mvn/wrapper/maven-wrapper.jar
 
 ### STS ###
 .apt_generated
@@ -20,6 +16,9 @@ application-oauth.properties
 *.iws
 *.iml
 *.ipr
+src/main/resources/application-aws.properties
+src/main/resources/application-oauth.properties
+src/main/resources/application-real-db.properties
 
 ### NetBeans ###
 /nbproject/private/
@@ -28,12 +27,7 @@ application-oauth.properties
 /nbdist/
 /.nb-gradle/
 build/
-!**/src/main/**/build/
-!**/src/test/**/build/
 
 ### VS Code ###
 .vscode/
 .DS_Store
-src/main/resources/application-aws.properties
-src/main/resources/application-oauth.properties
-src/main/resources/application-real-db.properties

--- a/server/collusic-be/src/main/java/com/collusic/collusicbe/config/auth/CustomOAuth2UserService.java
+++ b/server/collusic-be/src/main/java/com/collusic/collusicbe/config/auth/CustomOAuth2UserService.java
@@ -3,7 +3,6 @@ package com.collusic.collusicbe.config.auth;
 import com.collusic.collusicbe.domain.member.Member;
 import com.collusic.collusicbe.domain.member.MemberRepository;
 import com.collusic.collusicbe.domain.member.Role;
-import com.sun.tools.javac.util.List;
 import lombok.RequiredArgsConstructor;
 import org.springframework.security.core.authority.SimpleGrantedAuthority;
 import org.springframework.security.oauth2.client.userinfo.DefaultOAuth2UserService;
@@ -13,6 +12,7 @@ import org.springframework.security.oauth2.core.user.DefaultOAuth2User;
 import org.springframework.security.oauth2.core.user.OAuth2User;
 import org.springframework.stereotype.Service;
 
+import java.util.List;
 import java.util.Optional;
 
 @RequiredArgsConstructor

--- a/server/collusic-be/src/main/java/com/collusic/collusicbe/service/MemberService.java
+++ b/server/collusic-be/src/main/java/com/collusic/collusicbe/service/MemberService.java
@@ -1,0 +1,18 @@
+package com.collusic.collusicbe.service;
+
+import com.collusic.collusicbe.domain.member.Member;
+import com.collusic.collusicbe.domain.member.MemberRepository;
+import com.collusic.collusicbe.web.controller.dto.SignUpRequestDto;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+@RequiredArgsConstructor
+@Service
+public class MemberService {
+
+    private final MemberRepository memberRepository;
+
+    public Member signUp(SignUpRequestDto signUpRequestDto) {
+        return memberRepository.save(signUpRequestDto.toEntity());
+    }
+}

--- a/server/collusic-be/src/main/java/com/collusic/collusicbe/util/JWTUtil.java
+++ b/server/collusic-be/src/main/java/com/collusic/collusicbe/util/JWTUtil.java
@@ -39,14 +39,6 @@ public class JWTUtil {
                    .compact();
     }
 
-    public static String parseClaimToEmail(String token) {
-        return (String) Jwts.parser()
-                            .setSigningKey(kid)
-                            .parseClaimsJws(token)
-                            .getBody()
-                            .get("email");
-    }
-
     private static Map<String, Object> jwtHeaders() {
         Map<String, Object> headers = new HashMap<>();
         headers.put("typ", "JWT");

--- a/server/collusic-be/src/main/java/com/collusic/collusicbe/web/auth/OAuth2Controller.java
+++ b/server/collusic-be/src/main/java/com/collusic/collusicbe/web/auth/OAuth2Controller.java
@@ -26,19 +26,21 @@ public class OAuth2Controller {
         OAuth2ClientService oAuth2ClientService = oAuth2ProviderClientManager.getClientService(provider);
         OAuth2Response response = oAuth2ClientService.requestLogin(authCode);
         String email = (String) response.getAttributes().get("email");
+        String authId = (String) response.getAttributes().get("sub");
 
         Optional<Member> member = memberRepository.findByEmail(email);
-        OAuth2LoginResponseDto responseDto = afterOAuth2Login(member, SnsType.valueOf(provider.toUpperCase()), email);
+        OAuth2LoginResponseDto responseDto = afterOAuth2Login(member, SnsType.valueOf(provider.toUpperCase()), email, authId);
 
         return ResponseEntity.ok(responseDto);
     }
 
-    private OAuth2LoginResponseDto afterOAuth2Login(Optional<Member> member, SnsType snsType, String email) {
+    private OAuth2LoginResponseDto afterOAuth2Login(Optional<Member> member, SnsType snsType, String email, String authId) {
         if (!member.isPresent()) {
             return OAuth2LoginResponseDto.builder()
                                          .responseType(OAuth2LoginResponseType.SIGN_UP)
                                          .snsType(snsType)
                                          .email(email)
+                                         .authId(authId)
                                          .build();
         }
 

--- a/server/collusic-be/src/main/java/com/collusic/collusicbe/web/auth/OAuth2LoginResponseDto.java
+++ b/server/collusic-be/src/main/java/com/collusic/collusicbe/web/auth/OAuth2LoginResponseDto.java
@@ -15,7 +15,7 @@ public class OAuth2LoginResponseDto {
 
     @Builder
     public OAuth2LoginResponseDto(OAuth2LoginResponseType responseType, SnsType snsType,
-                                  String message, String accessToken, String refreshToken, String email) {
+                                  String message, String accessToken, String refreshToken, String email, String authId) {
         this.responseType = responseType;
 
         attributes = new HashMap<>();
@@ -31,6 +31,9 @@ public class OAuth2LoginResponseDto {
         }
         if (email != null) {
             attributes.put("email", email);
+        }
+        if (authId != null) {
+            attributes.put("authId", authId);
         }
     }
 }

--- a/server/collusic-be/src/main/java/com/collusic/collusicbe/web/auth/google/dto/GoogleTokenResponse.java
+++ b/server/collusic-be/src/main/java/com/collusic/collusicbe/web/auth/google/dto/GoogleTokenResponse.java
@@ -1,6 +1,5 @@
 package com.collusic.collusicbe.web.auth.google.dto;
 
-import com.collusic.collusicbe.util.JWTUtil;
 import com.collusic.collusicbe.web.auth.OAuth2Response;
 import com.fasterxml.jackson.databind.PropertyNamingStrategies;
 import com.fasterxml.jackson.databind.annotation.JsonNaming;
@@ -35,7 +34,6 @@ public class GoogleTokenResponse implements OAuth2Response {
         attributes.put("expires_in", expiresIn);
         attributes.put("refresh_token", refreshToken);
         attributes.put("scope", scope);
-        attributes.put("email", JWTUtil.parseClaimToEmail(idToken));
 
         return attributes;
     }

--- a/server/collusic-be/src/main/java/com/collusic/collusicbe/web/auth/naver/dto/NaverProfileResponse.java
+++ b/server/collusic-be/src/main/java/com/collusic/collusicbe/web/auth/naver/dto/NaverProfileResponse.java
@@ -21,6 +21,8 @@ public class NaverProfileResponse implements OAuth2Response {
 
     @Override
     public Map<String, Object> getAttributes() {
-        return response;
+        this.response.put("sub", this.response.get("id"));
+        this.response.remove("id");
+        return this.response;
     }
 }

--- a/server/collusic-be/src/main/java/com/collusic/collusicbe/web/controller/MemberController.java
+++ b/server/collusic-be/src/main/java/com/collusic/collusicbe/web/controller/MemberController.java
@@ -1,0 +1,33 @@
+package com.collusic.collusicbe.web.controller;
+
+import com.collusic.collusicbe.domain.member.Member;
+import com.collusic.collusicbe.service.MemberService;
+import com.collusic.collusicbe.util.JWTUtil;
+import com.collusic.collusicbe.web.auth.OAuth2LoginResponseType;
+import com.collusic.collusicbe.web.controller.dto.SignUpRequestDto;
+import com.collusic.collusicbe.web.controller.dto.SignUpResponseDto;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RestController;
+
+@RequiredArgsConstructor
+@RestController
+public class MemberController {
+
+    private final MemberService memberService;
+
+    @PostMapping("/members")
+    public ResponseEntity<SignUpResponseDto> signUp(@RequestBody SignUpRequestDto signUpRequestDto) { // TODO: validation
+        Member member = memberService.signUp(signUpRequestDto);
+
+        SignUpResponseDto responseBody = SignUpResponseDto.builder()
+                                                          .responseType(OAuth2LoginResponseType.SIGN_IN)
+                                                          .authId(member.getAuthId())
+                                                          .accessToken(JWTUtil.createAccessToken(member.getEmail()))
+                                                          .refreshToken(JWTUtil.createRefreshToken(member.getEmail()))
+                                                          .build();
+        return ResponseEntity.ok(responseBody);
+    }
+}

--- a/server/collusic-be/src/main/java/com/collusic/collusicbe/web/controller/dto/SignUpRequestDto.java
+++ b/server/collusic-be/src/main/java/com/collusic/collusicbe/web/controller/dto/SignUpRequestDto.java
@@ -1,0 +1,34 @@
+package com.collusic.collusicbe.web.controller.dto;
+
+import com.collusic.collusicbe.domain.member.Member;
+import com.collusic.collusicbe.domain.member.Role;
+import com.collusic.collusicbe.domain.member.SnsType;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor
+public class SignUpRequestDto {
+
+    private String email;
+    private String authId;
+    private String nickName;
+    private SnsType snsType;
+
+    public SignUpRequestDto(String email, String authId, String nickName, String snsType) {
+        this.email = email;
+        this.authId = authId;
+        this.nickName = nickName;
+        this.snsType = SnsType.valueOf(snsType);
+    }
+
+    public Member toEntity() {
+        return Member.builder()
+                     .authId(authId)
+                     .email(email)
+                     .nickname(nickName)
+                     .snsType(snsType)
+                     .role(Role.USER)
+                     .build();
+    }
+}

--- a/server/collusic-be/src/main/java/com/collusic/collusicbe/web/controller/dto/SignUpResponseDto.java
+++ b/server/collusic-be/src/main/java/com/collusic/collusicbe/web/controller/dto/SignUpResponseDto.java
@@ -1,0 +1,40 @@
+package com.collusic.collusicbe.web.controller.dto;
+
+import com.collusic.collusicbe.domain.member.SnsType;
+import com.collusic.collusicbe.web.auth.OAuth2LoginResponseType;
+import lombok.Builder;
+import lombok.Getter;
+
+import java.util.HashMap;
+import java.util.Map;
+
+@Getter
+public class SignUpResponseDto {
+
+    private final OAuth2LoginResponseType responseType;
+    private final Map<String, Object> attributes;
+
+    @Builder
+    public SignUpResponseDto(OAuth2LoginResponseType responseType, SnsType snsType,
+                                  String message, String accessToken, String refreshToken, String email, String authId) {
+        this.responseType = responseType;
+
+        attributes = new HashMap<>();
+        attributes.put("sns_type", snsType);
+        if (message != null) {
+            attributes.put("error_message", message);
+        }
+        if (accessToken != null) {
+            attributes.put("access_token", accessToken);
+        }
+        if (refreshToken != null) {
+            attributes.put("refresh_token", refreshToken);
+        }
+        if (email != null) {
+            attributes.put("email", email);
+        }
+        if (authId != null) {
+            attributes.put("authId", authId);
+        }
+    }
+}


### PR DESCRIPTION
## 구현 기능 
* 클라이언트의 요청 정보를 바탕으로 회원가입 API를 구현함.


## 논의하고 싶은 내용
* 에러 핸들링과 Validation은 추후 구현 예정 (회원가입 실패 케이스들)
    
Close #154 