### PR TITLE
faet/158: Swagger 적용 완료

### DIFF
--- a/server/collusic-be/pom.xml
+++ b/server/collusic-be/pom.xml
@@ -84,6 +84,14 @@
             <artifactId>spring-boot-starter-data-redis</artifactId>
         </dependency>
 
+        <!-- Swagger 3.0 -->
+        <dependency>
+            <groupId>io.springfox</groupId>
+            <artifactId>springfox-boot-starter</artifactId>
+            <version>3.0.0</version>
+        </dependency>
+
+
     </dependencies>
 
     <build>

--- a/server/collusic-be/src/main/java/com/collusic/collusicbe/config/SecurityConfig.java
+++ b/server/collusic-be/src/main/java/com/collusic/collusicbe/config/SecurityConfig.java
@@ -27,6 +27,7 @@ public class SecurityConfig extends WebSecurityConfigurerAdapter {
                 .formLogin().disable()
                 .authorizeRequests(request -> request.antMatchers(HttpMethod.POST, "/members").permitAll()
                                                      .antMatchers(HttpMethod.GET, "/oauth2/login/**").permitAll()
+                                                     .antMatchers("/swagger-ui/**", "/swagger-resources/**", "/v3/api-docs").permitAll()
                                                      .anyRequest().authenticated())
                 .addFilterAt(new JWTAuthenticationFilter(authenticationManager()), BasicAuthenticationFilter.class);
     }

--- a/server/collusic-be/src/main/java/com/collusic/collusicbe/config/SwaggerConfig.java
+++ b/server/collusic-be/src/main/java/com/collusic/collusicbe/config/SwaggerConfig.java
@@ -1,0 +1,35 @@
+package com.collusic.collusicbe.config;
+
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import springfox.documentation.builders.ApiInfoBuilder;
+import springfox.documentation.builders.PathSelectors;
+import springfox.documentation.builders.RequestHandlerSelectors;
+import springfox.documentation.service.ApiInfo;
+import springfox.documentation.spi.DocumentationType;
+import springfox.documentation.spring.web.plugins.Docket;
+import springfox.documentation.swagger2.annotations.EnableSwagger2;
+
+@Configuration
+@EnableSwagger2
+public class SwaggerConfig {
+
+    @Bean
+    public Docket api() {
+        return new Docket(DocumentationType.OAS_30)
+                .useDefaultResponseMessages(false)
+                .select()
+                .apis(RequestHandlerSelectors.basePackage("com.collusic.collusicbe"))
+                .paths(PathSelectors.any())
+                .build()
+                .apiInfo(apiInfo());
+    }
+
+    private ApiInfo apiInfo() {
+        return new ApiInfoBuilder()
+                .title("Collusic API Documentation")
+                .description("Collusic API 서버 명세서")
+                .version("1.0")
+                .build();
+    }
+}

--- a/server/collusic-be/src/main/java/com/collusic/collusicbe/web/auth/OAuth2Controller.java
+++ b/server/collusic-be/src/main/java/com/collusic/collusicbe/web/auth/OAuth2Controller.java
@@ -6,6 +6,7 @@ import com.collusic.collusicbe.domain.member.SnsType;
 import com.collusic.collusicbe.service.TokenService;
 import com.collusic.collusicbe.util.ParsingUtil;
 import com.collusic.collusicbe.web.controller.dto.TokenResponseDto;
+import io.swagger.v3.oas.annotations.Operation;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.GetMapping;
@@ -25,6 +26,7 @@ public class OAuth2Controller {
     private final MemberRepository memberRepository;
     private final TokenService tokenService;
 
+    @Operation(summary = "sns 로그인", description = "sns로부터 받은 auth code를 query string으로 보내 로그인 및 회원정보 응답")
     @GetMapping("/oauth2/login/{provider}")
     public ResponseEntity<OAuth2LoginResponseDto> loginToSns(@PathVariable String provider, @RequestParam Map<String, Object> authCode, HttpServletRequest request) {
         OAuth2ClientService oAuth2ClientService = oAuth2ProviderClientManager.getClientService(provider);

--- a/server/collusic-be/src/main/java/com/collusic/collusicbe/web/controller/MemberController.java
+++ b/server/collusic-be/src/main/java/com/collusic/collusicbe/web/controller/MemberController.java
@@ -8,6 +8,7 @@ import com.collusic.collusicbe.web.auth.OAuth2LoginResponseType;
 import com.collusic.collusicbe.web.controller.dto.SignUpRequestDto;
 import com.collusic.collusicbe.web.controller.dto.SignUpResponseDto;
 import com.collusic.collusicbe.web.controller.dto.TokenResponseDto;
+import io.swagger.v3.oas.annotations.Operation;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.PostMapping;
@@ -23,6 +24,7 @@ public class MemberController {
     private final MemberService memberService;
     private final TokenService tokenService;
 
+    @Operation(summary = "회원가입", description = "회원정보를 통해 회원가입 후 성공 시 access token, refresh token 응답")
     @PostMapping("/members")
     public ResponseEntity<SignUpResponseDto> signUp(@RequestBody SignUpRequestDto signUpRequestDto, HttpServletRequest request) { // TODO: validation
         Member member = memberService.signUp(signUpRequestDto);

--- a/server/collusic-be/src/main/java/com/collusic/collusicbe/web/controller/TokenController.java
+++ b/server/collusic-be/src/main/java/com/collusic/collusicbe/web/controller/TokenController.java
@@ -3,6 +3,7 @@ package com.collusic.collusicbe.web.controller;
 import com.collusic.collusicbe.service.TokenService;
 import com.collusic.collusicbe.util.ParsingUtil;
 import com.collusic.collusicbe.web.controller.dto.TokenResponseDto;
+import io.swagger.v3.oas.annotations.Operation;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
@@ -20,6 +21,7 @@ public class TokenController {
 
     private final TokenService tokenService;
 
+    @Operation(summary = "토큰 재발급", description = "refresh token을 통한 access token, refresh token 재발급")
     @PostMapping("/tokens/reissue")
     public ResponseEntity<TokenResponseDto> reissue(@RequestHeader("Authorization") String token, HttpServletRequest request) {
         token = token.substring(BEARER_PREFIX.length());

--- a/server/collusic-be/src/main/resources/application.properties
+++ b/server/collusic-be/src/main/resources/application.properties
@@ -21,5 +21,7 @@ spring.mvc.hiddenmethod.filter.enabled=true
 
 spring.profiles.include=aws, oauth
 
+spring.mvc.pathmatch.matching-strategy = ant_path_matcher
+
 spring.redis.host=localhost
 spring.redis.port=6379


### PR DESCRIPTION
## 구현 기능 
- swagger 적용 완료 (document 접근 url -> **{base_url}/swagger-ui/index.html**)

![image](https://user-images.githubusercontent.com/41420639/181579314-fce9ef61-7dcb-4a86-bf2b-68a92acdbf35.png)


## 논의하고 싶은 내용 (optional) 
- 아직 validation 및 exception handling이 되어있지 않아서 status code가 ok만 이용되고 있습니다. 향후 프론트와 협의하여 상태 코드 정해야할 듯합니다.

    
Close #158 
