### PR TITLE
feat/168 - 닉네임 중복 검사 API 구현

### DIFF
--- a/server/collusic-be/src/main/java/com/collusic/collusicbe/domain/member/MemberRepository.java
+++ b/server/collusic-be/src/main/java/com/collusic/collusicbe/domain/member/MemberRepository.java
@@ -2,9 +2,12 @@ package com.collusic.collusicbe.domain.member;
 
 import org.springframework.data.jpa.repository.JpaRepository;
 
+import java.util.List;
 import java.util.Optional;
 
 public interface MemberRepository extends JpaRepository<Member, Long> {
 
     Optional<Member> findByEmail(String email);
+
+    List<Member> findMemberByNickname(String nickname);
 }

--- a/server/collusic-be/src/main/java/com/collusic/collusicbe/service/MemberService.java
+++ b/server/collusic-be/src/main/java/com/collusic/collusicbe/service/MemberService.java
@@ -21,7 +21,7 @@ public class MemberService {
     public boolean isDuplicatedNickname(String nickname) {
         List<Member> members = memberRepository.findMemberByNickname(nickname);
 
-        if (members.size() > 1) {
+        if (members.size() > 0) {
             return true;
         }
 

--- a/server/collusic-be/src/main/java/com/collusic/collusicbe/service/MemberService.java
+++ b/server/collusic-be/src/main/java/com/collusic/collusicbe/service/MemberService.java
@@ -6,6 +6,8 @@ import com.collusic.collusicbe.web.controller.dto.SignUpRequestDto;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 
+import java.util.List;
+
 @RequiredArgsConstructor
 @Service
 public class MemberService {
@@ -14,5 +16,15 @@ public class MemberService {
 
     public Member signUp(SignUpRequestDto signUpRequestDto) {
         return memberRepository.save(signUpRequestDto.toEntity());
+    }
+
+    public boolean isDuplicatedNickname(String nickname) {
+        List<Member> members = memberRepository.findMemberByNickname(nickname);
+
+        if (members.size() > 1) {
+            return true;
+        }
+
+        return false;
     }
 }

--- a/server/collusic-be/src/main/java/com/collusic/collusicbe/web/controller/MemberController.java
+++ b/server/collusic-be/src/main/java/com/collusic/collusicbe/web/controller/MemberController.java
@@ -38,6 +38,7 @@ public class MemberController {
         return ResponseEntity.ok(responseBody);
     }
 
+    @Operation(summary = "닉네임 중복 체크", description = "회원가입 과정 중 닉네임 중복 체크에 대한 결과를 응답")
     @GetMapping("/members/{nickname}")
     public ResponseEntity<NicknameValidationResponseDto> validateDuplicatedNickname(@PathVariable String nickname) {
         if (memberService.isDuplicatedNickname(nickname)) {

--- a/server/collusic-be/src/main/java/com/collusic/collusicbe/web/controller/MemberController.java
+++ b/server/collusic-be/src/main/java/com/collusic/collusicbe/web/controller/MemberController.java
@@ -5,13 +5,16 @@ import com.collusic.collusicbe.service.MemberService;
 import com.collusic.collusicbe.service.TokenService;
 import com.collusic.collusicbe.util.ParsingUtil;
 import com.collusic.collusicbe.web.auth.OAuth2LoginResponseType;
+import com.collusic.collusicbe.web.controller.dto.NicknameValidationResponseDto;
 import com.collusic.collusicbe.web.controller.dto.SignUpRequestDto;
 import com.collusic.collusicbe.web.controller.dto.SignUpResponseDto;
 import com.collusic.collusicbe.web.controller.dto.TokenResponseDto;
 import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 
 import javax.servlet.http.HttpServletRequest;
@@ -34,5 +37,23 @@ public class MemberController {
                                                           .refreshToken(tokens.getRefreshToken())
                                                           .build();
         return ResponseEntity.ok(responseBody);
+    }
+
+    @PostMapping("/members/{nickname}")
+    public ResponseEntity<NicknameValidationResponseDto> validateDuplicatedNickname(@RequestParam String nickname) {
+        if (memberService.isDuplicatedNickname(nickname)) {
+            NicknameValidationResponseDto nicknameValidationResponseDto = NicknameValidationResponseDto.builder()
+                                                                                                       .result("fail")
+                                                                                                       .message("중복된 닉네임입니다.")
+                                                                                                       .build();
+            return ResponseEntity.status(HttpStatus.CONFLICT)
+                                 .body(nicknameValidationResponseDto);
+        }
+
+        NicknameValidationResponseDto nicknameValidationResponseDto = NicknameValidationResponseDto.builder()
+                                                                                                   .result("success")
+                                                                                                   .message("사용 가능한 닉네임입니다.")
+                                                                                                   .build();
+        return ResponseEntity.ok(nicknameValidationResponseDto);
     }
 }

--- a/server/collusic-be/src/main/java/com/collusic/collusicbe/web/controller/MemberController.java
+++ b/server/collusic-be/src/main/java/com/collusic/collusicbe/web/controller/MemberController.java
@@ -37,7 +37,7 @@ public class MemberController {
     }
 
     @GetMapping("/members/{nickname}")
-    public ResponseEntity<NicknameValidationResponseDto> validateDuplicatedNickname(@RequestParam String nickname) {
+    public ResponseEntity<NicknameValidationResponseDto> validateDuplicatedNickname(@PathVariable String nickname) {
         if (memberService.isDuplicatedNickname(nickname)) {
             NicknameValidationResponseDto nicknameValidationResponseDto = NicknameValidationResponseDto.builder()
                                                                                                        .isDuplicated(true)

--- a/server/collusic-be/src/main/java/com/collusic/collusicbe/web/controller/MemberController.java
+++ b/server/collusic-be/src/main/java/com/collusic/collusicbe/web/controller/MemberController.java
@@ -12,10 +12,7 @@ import com.collusic.collusicbe.web.controller.dto.TokenResponseDto;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
-import org.springframework.web.bind.annotation.PostMapping;
-import org.springframework.web.bind.annotation.RequestBody;
-import org.springframework.web.bind.annotation.RequestParam;
-import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.bind.annotation.*;
 
 import javax.servlet.http.HttpServletRequest;
 
@@ -39,11 +36,11 @@ public class MemberController {
         return ResponseEntity.ok(responseBody);
     }
 
-    @PostMapping("/members/{nickname}")
+    @GetMapping("/members/{nickname}")
     public ResponseEntity<NicknameValidationResponseDto> validateDuplicatedNickname(@RequestParam String nickname) {
         if (memberService.isDuplicatedNickname(nickname)) {
             NicknameValidationResponseDto nicknameValidationResponseDto = NicknameValidationResponseDto.builder()
-                                                                                                       .result("fail")
+                                                                                                       .isDuplicated(true)
                                                                                                        .message("중복된 닉네임입니다.")
                                                                                                        .build();
             return ResponseEntity.status(HttpStatus.CONFLICT)
@@ -51,7 +48,7 @@ public class MemberController {
         }
 
         NicknameValidationResponseDto nicknameValidationResponseDto = NicknameValidationResponseDto.builder()
-                                                                                                   .result("success")
+                                                                                                   .isDuplicated(false)
                                                                                                    .message("사용 가능한 닉네임입니다.")
                                                                                                    .build();
         return ResponseEntity.ok(nicknameValidationResponseDto);

--- a/server/collusic-be/src/main/java/com/collusic/collusicbe/web/controller/dto/NicknameValidationResponseDto.java
+++ b/server/collusic-be/src/main/java/com/collusic/collusicbe/web/controller/dto/NicknameValidationResponseDto.java
@@ -1,0 +1,17 @@
+package com.collusic.collusicbe.web.controller.dto;
+
+import lombok.Builder;
+import lombok.Getter;
+
+@Getter
+public class NicknameValidationResponseDto {
+
+    private String result;
+    private String message;
+
+    @Builder
+    public NicknameValidationResponseDto(String result, String message) {
+        this.result = result;
+        this.message = message;
+    }
+}

--- a/server/collusic-be/src/main/java/com/collusic/collusicbe/web/controller/dto/NicknameValidationResponseDto.java
+++ b/server/collusic-be/src/main/java/com/collusic/collusicbe/web/controller/dto/NicknameValidationResponseDto.java
@@ -6,12 +6,12 @@ import lombok.Getter;
 @Getter
 public class NicknameValidationResponseDto {
 
-    private String result;
+    private boolean isDuplicated;
     private String message;
 
     @Builder
-    public NicknameValidationResponseDto(String result, String message) {
-        this.result = result;
+    public NicknameValidationResponseDto(boolean isDuplicated, String message) {
+        this.isDuplicated = isDuplicated;
         this.message = message;
     }
 }


### PR DESCRIPTION
## 구현 기능 
* 닉네임 중복 검사 API 구현


## 논의하고 싶은 내용 (optional) 
* 닉네임 중복 시 Exception을 보내면 좋을지 혹은 boolean으로 중복 여부를 구분할지. 만약 Exception을 보내는 것이 좋다면 추상화 레벨을 고려하여 재설계하여 반영할 예정
    
Close #168 
