### PR TITLE
feat/172 구글 Oauth 로그인/회원가입 기능 구현 완료

### DIFF
--- a/client/.gitignore
+++ b/client/.gitignore
@@ -13,6 +13,7 @@
 
 # misc
 .DS_Store
+.env
 .env.local
 .env.development.local
 .env.test.local

--- a/client/src/App.tsx
+++ b/client/src/App.tsx
@@ -6,6 +6,8 @@ import { NavBarView } from "./view/NavBarView";
 import { SignInViewModel } from "./viewmodel/SignInViewModel";
 import { StartPageView } from "./view/StartPageView";
 import { SignUpViewModel } from "./viewmodel/SignUpViewModel";
+import { RedirectViewModel } from "./viewmodel/RedirectViewModel";
+import { ProjectListView } from "./view/ProjectListView";
 
 function App() {
   return (
@@ -14,7 +16,9 @@ function App() {
       <Routes>
         <Route path="/signin" element={<SignInViewModel />} />
         <Route path="/signup" element={<SignUpViewModel />} />
+        <Route path="/auth/redirect" element={<RedirectViewModel />} />
         <Route path="/" element={<StartPageView />} />
+        <Route path="/projectlist" element={<ProjectListView />} />
       </Routes>
     </BrowserRouter>
   );

--- a/client/src/components/LoginButton.tsx
+++ b/client/src/components/LoginButton.tsx
@@ -7,7 +7,7 @@ type LoginButtonProps = {
   backgroundColor: string;
   textColor: string;
   src: string;
-  onClickHandler: Function;
+  onClickHandler(): void;
 };
 
 export function LoginButton({ innerText, backgroundColor, textColor, src, onClickHandler }: LoginButtonProps) {
@@ -16,7 +16,7 @@ export function LoginButton({ innerText, backgroundColor, textColor, src, onClic
       type="button"
       className="login-button"
       style={{ backgroundColor: `${backgroundColor}`, color: `${textColor}` }}
-      onClick={() => onClickHandler}
+      onClick={onClickHandler}
     >
       <img src={src} alt="logo" />
       <p>{innerText}</p>

--- a/client/src/components/LoginButton.tsx
+++ b/client/src/components/LoginButton.tsx
@@ -7,7 +7,7 @@ type LoginButtonProps = {
   backgroundColor: string;
   textColor: string;
   src: string;
-  onClickHandler(): void;
+  onClickHandler: Function;
 };
 
 export function LoginButton({ innerText, backgroundColor, textColor, src, onClickHandler }: LoginButtonProps) {
@@ -16,7 +16,7 @@ export function LoginButton({ innerText, backgroundColor, textColor, src, onClic
       type="button"
       className="login-button"
       style={{ backgroundColor: `${backgroundColor}`, color: `${textColor}` }}
-      onClick={onClickHandler}
+      onClick={() => onClickHandler}
     >
       <img src={src} alt="logo" />
       <p>{innerText}</p>

--- a/client/src/components/Modal.tsx
+++ b/client/src/components/Modal.tsx
@@ -4,6 +4,7 @@ import "../utils/style/Modal.scss";
 
 type modalProps = {
   showModal: boolean;
+  // eslint-disable-next-line no-unused-vars
   setShowModal(arg: boolean): void;
   children: React.ReactNode;
 };

--- a/client/src/mocks/handlers/user.ts
+++ b/client/src/mocks/handlers/user.ts
@@ -4,11 +4,11 @@ export const signIn = rest.get("http://localhost:8080/oauth2/login/:provider", (
   res(
     ctx.status(200),
     ctx.json({
-      response_type: "SIGN_UP",
+      responseType: "SIGN_UP",
       email: "singco@gmail.com",
       authId: "singco",
       profile: "",
-      sns_type: "google",
+      snsType: "kakao",
     }),
   ),
 );
@@ -17,9 +17,9 @@ export const signUp = rest.post("http://localhost:8080/members", (req, res, ctx)
   res(
     ctx.status(200),
     ctx.json({
-      response_type: "SIGN_IN",
-      access_token: "slkdfjaiefj.sefiajsef.sfiaejlf",
-      resfresh_token: "dkfjaie.feiajfiose.fjsiae212d",
+      responseType: "SIGN_IN",
+      accessToken: "slkdfjaiefj.sefiajsef.sfiaejlf",
+      resfreshToken: "dkfjaie.feiajfiose.fjsiae212d",
     }),
   ),
 );

--- a/client/src/model/userModel.ts
+++ b/client/src/model/userModel.ts
@@ -1,0 +1,11 @@
+import { atom } from "recoil";
+
+export const loginTypeState = atom({
+  key: "LoginTypeState",
+  default: "",
+});
+
+export const refreshTokenState = atom({
+  key: "RefreshTokenState",
+  default: "",
+});

--- a/client/src/utils/axios.ts
+++ b/client/src/utils/axios.ts
@@ -1,8 +1,9 @@
 import axios from "axios";
 
 export const API = axios.create({
-  baseURL: "http://collusic.com/",
+  baseURL: process.env.REACT_APP_MOCK_API,
   headers: { "X-Custom-Header": "foobar" },
+  withCredentials: true,
   timeout: 1000,
 });
 

--- a/client/src/view/ProjectListView.tsx
+++ b/client/src/view/ProjectListView.tsx
@@ -1,0 +1,5 @@
+import React from "react";
+
+export function ProjectListView() {
+  return <div>프로젝트 목록 페이지</div>
+}

--- a/client/src/view/SignInView.tsx
+++ b/client/src/view/SignInView.tsx
@@ -4,10 +4,12 @@ import "../utils/style/login.scss";
 import { LoginButton } from "../components/LoginButton";
 
 type signInProps = {
-  onClickHandler: Function;
+  naverClickHandler(): void;
+  kakaoClickHandler(): void;
+  googleClickHandler(): void;
 };
 
-export function SignInView({ onClickHandler }: signInProps) {
+export function SignInView({ naverClickHandler, kakaoClickHandler, googleClickHandler }: signInProps) {
   return (
     <div className="login-view">
       <LoginButton
@@ -15,21 +17,21 @@ export function SignInView({ onClickHandler }: signInProps) {
         backgroundColor="#03c75a"
         textColor="#fff"
         src="../assets/login/naver.svg"
-        onClickHandler={onClickHandler}
+        onClickHandler={naverClickHandler}
       />
       <LoginButton
         innerText="카카오로 시작하기"
         backgroundColor="#fee500"
         textColor="#000"
         src="../assets/login/kakao.svg"
-        onClickHandler={onClickHandler}
+        onClickHandler={kakaoClickHandler}
       />
       <LoginButton
         innerText="구글로 시작하기"
         backgroundColor="#fff"
         textColor="#000"
         src="../assets/login/google.svg"
-        onClickHandler={onClickHandler}
+        onClickHandler={googleClickHandler}
       />
     </div>
   );

--- a/client/src/view/SignInView.tsx
+++ b/client/src/view/SignInView.tsx
@@ -4,7 +4,7 @@ import "../utils/style/login.scss";
 import { LoginButton } from "../components/LoginButton";
 
 type signInProps = {
-  onClickHandler(): void;
+  onClickHandler: Function;
 };
 
 export function SignInView({ onClickHandler }: signInProps) {

--- a/client/src/viewmodel/RedirectViewModel.tsx
+++ b/client/src/viewmodel/RedirectViewModel.tsx
@@ -1,0 +1,55 @@
+import React, { useEffect } from "react";
+import { useRecoilValue, useSetRecoilState } from "recoil";
+import { useSearchParams, useNavigate } from "react-router-dom";
+import { AxiosResponse } from "axios";
+
+import { API } from "../utils/axios";
+import { loginTypeState, refreshTokenState } from "../model/userModel";
+import { modalOpenState } from "../model/signInModel";
+import { signUpState } from "../model/signUpModel";
+
+export function RedirectViewModel() {
+  const setModalOpenState = useSetRecoilState(modalOpenState);
+  const setSignUpState = useSetRecoilState(signUpState);
+  const setRefreshToken = useSetRecoilState(refreshTokenState);
+  const loginType = useRecoilValue(loginTypeState);
+  const navigate = useNavigate();
+  const [query] = useSearchParams();
+  const authCode = query.get("code");
+  const state = query.get("state");
+
+  useEffect(() => {
+    const getLoginState = async () => {
+      try {
+        const { data }: AxiosResponse = await API.get(`/oauth2/login/kakao`, {
+          data: {
+            auth_code: (authCode as string) + state,
+          },
+        });
+
+        if (data.responseType === "SIGN_IN") {
+          const { accessToken, refreshToken } = data;
+          setRefreshToken(refreshToken);
+          API.defaults.headers.common.Authorization = `Bearer ${accessToken}`;
+        }
+
+        if (data.responseType === "SIGN_UP") {
+          setModalOpenState(false);
+          setSignUpState(true);
+          navigate("/signup", { state: data });
+        }
+
+        if (data.responseType === "ERROR") {
+          alert(data.errorMessage);
+          navigate("/signin");
+        }
+      } catch (err) {
+        console.error(err);
+      }
+    };
+
+    getLoginState();
+  }, [loginType]);
+
+  return <div>{loginType} 로그인 로딩중</div>;
+}

--- a/client/src/viewmodel/SignInViewModel.tsx
+++ b/client/src/viewmodel/SignInViewModel.tsx
@@ -1,22 +1,35 @@
 import React from "react";
-import { useNavigate } from "react-router-dom";
-import { useSetRecoilState } from "recoil";
+import { useRecoilState } from "recoil";
 
 import { SignInView } from "../view/SignInView";
-
-import { modalOpenState } from "../model/signInModel";
-import { signUpState } from "../model/signUpModel";
+import { loginTypeState } from "../model/userModel";
 
 export function SignInViewModel() {
-  const navigate = useNavigate();
-  const setModalOpenSate = useSetRecoilState(modalOpenState);
-  const setSignUpState = useSetRecoilState(signUpState);
+  const [loginType, setLoginType] = useRecoilState(loginTypeState);
 
-  const onClickHandler = () => {
-    setModalOpenSate(false);
-    setSignUpState(true);
-    navigate("/signup");
+  const naverClickHandler = () => {
+    setLoginType("naver");
+    window.location.href =
+      "https://nid.naver.com/oauth2.0/authorize?response_type=code&client_id=37fxHiyXMIr6sxLm2MPe&scope=email&state=7IiQorH-lspV_Axq3aD2sSvI5bAVYVB1RY3R2o70Ilo%3D&redirect_uri=http://localhost:3000/oauth/redirect";
   };
 
-  return <SignInView onClickHandler={onClickHandler} />;
+  const kakaoClickHandler = () => {
+    setLoginType("kakao");
+    console.log(loginType);
+    window.location.href =
+      "https://kauth.kakao.com/oauth/authorize?response_type=code&client_id=6acab7ac79ce0a072e6ddf08861d28ed&scope=account_email openid&state=qYXwGnJBNMGJPabC1nmKuMn9CChc3WCF72mmr8HHRi8%3D&redirect_uri=http://localhost:3000/auth/redirect";
+  };
+  const googleClickHandler = () => {
+    setLoginType("google");
+    window.location.href =
+      "https://accounts.google.com/o/oauth2/v2/auth?response_type=code&client_id=717532271001-pu3fqqghv2rbi3ldeivht3pmlvaveep6.apps.googleusercontent.com&scope=emailopenid&state=vGT5WolwVcBKgizeawrLfpjUfxiVzE-RmJnioZGWIBI%3D&redirect_uri=http://localhost:3000/auth/redirect";
+  };
+
+  return (
+    <SignInView
+      naverClickHandler={naverClickHandler}
+      kakaoClickHandler={kakaoClickHandler}
+      googleClickHandler={googleClickHandler}
+    />
+  );
 }

--- a/client/src/viewmodel/SignInViewModel.tsx
+++ b/client/src/viewmodel/SignInViewModel.tsx
@@ -10,7 +10,7 @@ export function SignInViewModel() {
   const naverClickHandler = () => {
     setLoginType("naver");
     window.location.href =
-      "https://nid.naver.com/oauth2.0/authorize?response_type=code&client_id=37fxHiyXMIr6sxLm2MPe&scope=email&state=7IiQorH-lspV_Axq3aD2sSvI5bAVYVB1RY3R2o70Ilo%3D&redirect_uri=http://localhost:3000/oauth/redirect";
+      "https://nid.naver.com/oauth2.0/authorize?response_type=code&client_id=37fxHiyXMIr6sxLm2MPe&state=7IiQorH-lspV_Axq3aD2sSvI5bAVYVB1RY3R2o70Ilo%3D&redirect_uri=http://localhost:3000/auth/redirect";
   };
 
   const kakaoClickHandler = () => {
@@ -22,7 +22,7 @@ export function SignInViewModel() {
   const googleClickHandler = () => {
     setLoginType("google");
     window.location.href =
-      "https://accounts.google.com/o/oauth2/v2/auth?response_type=code&client_id=717532271001-pu3fqqghv2rbi3ldeivht3pmlvaveep6.apps.googleusercontent.com&scope=emailopenid&state=vGT5WolwVcBKgizeawrLfpjUfxiVzE-RmJnioZGWIBI%3D&redirect_uri=http://localhost:3000/auth/redirect";
+      "https://accounts.google.com/o/oauth2/v2/auth?response_type=code&client_id=717532271001-pu3fqqghv2rbi3ldeivht3pmlvaveep6.apps.googleusercontent.com&scope=email openid&state=vGT5WolwVcBKgizeawrLfpjUfxiVzE-RmJnioZGWIBI%3D&redirect_uri=http://localhost:3000/auth/redirect";
   };
 
   return (

--- a/client/src/viewmodel/SignUpViewModel.tsx
+++ b/client/src/viewmodel/SignUpViewModel.tsx
@@ -1,7 +1,8 @@
 import React from "react";
-import { useRecoilState, useRecoilValue } from "recoil";
+import { useRecoilState } from "recoil";
+import { useLocation } from "react-router-dom";
 
-import { signUpState, getSignUpUserInfo } from "../model/signUpModel";
+import { signUpState } from "../model/signUpModel";
 
 import { SignUpView } from "../view/SignUpView";
 import { Modal } from "../components/Modal";
@@ -10,9 +11,18 @@ import { TEST_API } from "../utils/axios";
 
 import "../utils/style/SignUp.scss";
 
+type UserData = {
+  responseType?: string;
+  email: string;
+  authId?: string;
+  profile: string;
+  snsType?: string;
+};
+
 export function SignUpViewModel() {
   const [signUp, setSignUp] = useRecoilState(signUpState);
-  const { profileSrc, email } = useRecoilValue(getSignUpUserInfo);
+  const location = useLocation();
+  const { email, profile } = location.state as UserData;
 
   const signUpEventHandler = (event: React.MouseEvent<HTMLButtonElement>) => {
     const nickName = (event.target as HTMLInputElement).parentElement!.querySelector("input")!.value;
@@ -26,7 +36,7 @@ export function SignUpViewModel() {
 
   return (
     <Modal showModal={signUp} setShowModal={setSignUp}>
-      <SignUpView profileSrc={profileSrc} email={email} signUpEventHandler={signUpEventHandler} />
+      <SignUpView profileSrc={profile} email={email} signUpEventHandler={signUpEventHandler} />
     </Modal>
   );
 }

--- a/client/src/viewmodel/SignUpViewModel.tsx
+++ b/client/src/viewmodel/SignUpViewModel.tsx
@@ -15,7 +15,7 @@ export function SignUpViewModel() {
   const { profileSrc, email } = useRecoilValue(getSignUpUserInfo);
 
   const signUpEventHandler = (event: React.MouseEvent<HTMLButtonElement>) => {
-    const nickName = event.target.parentElement.querySelector("input").value;
+    const nickName = (event.target as HTMLInputElement).parentElement!.querySelector("input")!.value;
 
     const formData = new FormData();
     formData.append("nickName", nickName);


### PR DESCRIPTION
## 구현 기능 
- 각 sns 로그인 타입에 따른 로그인 페이지로 리다이렉션
- redirect_url을 `localhost:3000/auth/redirect`로 설정
- loginType, refreshToken을 userModel에서 recoil atom으로 관리
- RedirectViewModel 에서 responseType에 따른 로그인 및 회원가입 로직 구현
- SIGN_UP 시 useNaviagte를 통해 SignUpViewModel로 회원정보 전달
- SignUpViewModel에서 useLocation을 통해 회원정보 수신


## 논의하고 싶은 내용 (optional) 
- userModel에서 recoil atom으로 관리하는 loginType이 RedirectViewModel에서 최신화되지 않아, /oauth2/login/${loginType}에서 loginType에 null값이 들어가 cors에러가 나타납니다.

## 공유하고 싶은 내용 (optional) 
- api 요청을 통해 전달받는 모든 key값은 camelCase를 적용
    
Close #{172}