### PR TITLE
refactor/183 : 응답 애트리뷰트에 대한 카멜케이스 적용

### DIFF
--- a/server/collusic-be/src/main/java/com/collusic/collusicbe/web/auth/OAuth2LoginResponseDto.java
+++ b/server/collusic-be/src/main/java/com/collusic/collusicbe/web/auth/OAuth2LoginResponseDto.java
@@ -19,15 +19,15 @@ public class OAuth2LoginResponseDto {
         this.responseType = responseType;
 
         attributes = new HashMap<>();
-        attributes.put("sns_type", snsType);
+        attributes.put("snsType", snsType);
         if (message != null) {
-            attributes.put("error_message", message);
+            attributes.put("errorMessage", message);
         }
         if (accessToken != null) {
-            attributes.put("access_token", accessToken);
+            attributes.put("accessToken", accessToken);
         }
         if (refreshToken != null) {
-            attributes.put("refresh_token", refreshToken);
+            attributes.put("refreshToken", refreshToken);
         }
         if (email != null) {
             attributes.put("email", email);

--- a/server/collusic-be/src/main/java/com/collusic/collusicbe/web/controller/dto/SignUpResponseDto.java
+++ b/server/collusic-be/src/main/java/com/collusic/collusicbe/web/controller/dto/SignUpResponseDto.java
@@ -20,13 +20,13 @@ public class SignUpResponseDto {
 
         attributes = new HashMap<>();
         if (message != null) {
-            attributes.put("error_message", message);
+            attributes.put("errorMessage", message);
         }
         if (accessToken != null) {
-            attributes.put("access_token", accessToken);
+            attributes.put("accessToken", accessToken);
         }
         if (refreshToken != null) {
-            attributes.put("refresh_token", refreshToken);
+            attributes.put("refreshToken", refreshToken);
         }
         if (email != null) {
             attributes.put("email", email);


### PR DESCRIPTION
## 구현 기능 
* 소셜 로그인 응답 Dto 및 회원가입 응답 Dto 애트리뷰트들에 대한 카멜 케이스 적용

## 공유하고 싶은 내용 
* 프론트엔드의 요청으로 내용 수정

    
Close #183 
