### PR TITLE
Refactor/197 : 닉네임 중복 체크 기능 응답 구조 수정

### DIFF
--- a/server/collusic-be/src/main/java/com/collusic/collusicbe/web/controller/MemberController.java
+++ b/server/collusic-be/src/main/java/com/collusic/collusicbe/web/controller/MemberController.java
@@ -11,6 +11,7 @@ import com.collusic.collusicbe.web.controller.dto.SignUpResponseDto;
 import com.collusic.collusicbe.web.controller.dto.TokenResponseDto;
 import io.swagger.v3.oas.annotations.Operation;
 import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.validation.annotation.Validated;
 import org.springframework.web.bind.annotation.*;
@@ -44,7 +45,7 @@ public class MemberController {
         memberService.validateDuplicatedNickname(nickname);
 
         NicknameValidationResponseDto nicknameValidationResponseDto = NicknameValidationResponseDto.builder()
-                                                                                                   .isDuplicated(false)
+                                                                                                   .status(HttpStatus.OK.value())
                                                                                                    .message("사용 가능한 닉네임입니다.")
                                                                                                    .build();
         return ResponseEntity.ok(nicknameValidationResponseDto);

--- a/server/collusic-be/src/main/java/com/collusic/collusicbe/web/controller/dto/NicknameValidationResponseDto.java
+++ b/server/collusic-be/src/main/java/com/collusic/collusicbe/web/controller/dto/NicknameValidationResponseDto.java
@@ -6,12 +6,12 @@ import lombok.Getter;
 @Getter
 public class NicknameValidationResponseDto {
 
-    private boolean isDuplicated;
+    private int status;
     private String message;
 
     @Builder
-    public NicknameValidationResponseDto(boolean isDuplicated, String message) {
-        this.isDuplicated = isDuplicated;
+    public NicknameValidationResponseDto(int status, String message) {
+        this.status = status;
         this.message = message;
     }
 }


### PR DESCRIPTION
## 구현 기능 
* 닉네임 중복 체크 API 성공 / 실패 응답에 status와 message를 활용할 수 있도록 한다.
* 프론트엔드와 상의 후 API 개선하기
    
Close #197 
