### PR TITLE
Refactor/199 : 리프레시 토큰 응답 방식 개선하기

### DIFF
--- a/server/collusic-be/src/main/java/com/collusic/collusicbe/service/TokenService.java
+++ b/server/collusic-be/src/main/java/com/collusic/collusicbe/service/TokenService.java
@@ -7,11 +7,11 @@ import org.springframework.stereotype.Service;
 
 import java.time.Duration;
 
+import static com.collusic.collusicbe.util.JWTUtil.REFRESH_TIME;
+
 @RequiredArgsConstructor
 @Service
 public class TokenService {
-
-    private static final long REFRESH_TIME = 60 * 60 * 24 * 7;
 
     private final RedisRepository redisRepository;
 

--- a/server/collusic-be/src/main/java/com/collusic/collusicbe/util/JWTUtil.java
+++ b/server/collusic-be/src/main/java/com/collusic/collusicbe/util/JWTUtil.java
@@ -13,8 +13,8 @@ import java.util.Map;
 
 public class JWTUtil {
 
-    private static final long ACCESS_TIME = 60 * 60;
-    private static final long REFRESH_TIME = 60 * 60 * 24 * 7;
+    private static final int ACCESS_TIME = 60 * 60;
+    public static final int REFRESH_TIME = 60 * 60 * 24 * 7;
     public static final String KEY = "collusic-new";
 
     public static String createAccessToken(String email, String role) {

--- a/server/collusic-be/src/main/java/com/collusic/collusicbe/web/controller/MemberController.java
+++ b/server/collusic-be/src/main/java/com/collusic/collusicbe/web/controller/MemberController.java
@@ -15,7 +15,11 @@ import org.springframework.http.ResponseEntity;
 import org.springframework.validation.annotation.Validated;
 import org.springframework.web.bind.annotation.*;
 
+import javax.servlet.http.Cookie;
 import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+
+import static com.collusic.collusicbe.util.JWTUtil.REFRESH_TIME;
 
 @RequiredArgsConstructor
 @RestController
@@ -26,15 +30,17 @@ public class MemberController {
 
     @Operation(summary = "회원가입", description = "회원정보를 통해 회원가입 후 성공 시 access token, refresh token 응답")
     @PostMapping("/members")
-    public ResponseEntity<SignUpResponseDto> signUp(@ModelAttribute @Validated SignUpRequestDto signUpRequestDto, HttpServletRequest request) { // TODO: validation
+    public ResponseEntity<SignUpResponseDto> signUp(@ModelAttribute @Validated SignUpRequestDto signUpRequestDto, HttpServletRequest request, HttpServletResponse response) { // TODO: validation
         Member member = memberService.signUp(signUpRequestDto);
         TokenResponseDto tokens = tokenService.issue(member.getEmail(), member.getRole().getKey(), ParsingUtil.getRemoteAddress(request));
 
         SignUpResponseDto responseBody = SignUpResponseDto.builder()
                                                           .responseType(OAuth2LoginResponseType.SIGN_IN)
                                                           .accessToken(tokens.getAccessToken())
-                                                          .refreshToken(tokens.getRefreshToken())
                                                           .build();
+
+        response.addCookie(setCookieWithRefreshToken(tokens.getRefreshToken()));
+
         return ResponseEntity.ok(responseBody);
     }
 
@@ -48,5 +54,13 @@ public class MemberController {
                                                                                                    .message("사용 가능한 닉네임입니다.")
                                                                                                    .build();
         return ResponseEntity.ok(nicknameValidationResponseDto);
+    }
+
+    private Cookie setCookieWithRefreshToken(String refreshToken) {
+        Cookie cookie = new Cookie("refreshToken", refreshToken);
+        cookie.setMaxAge(REFRESH_TIME);
+        cookie.setSecure(true);
+        cookie.setHttpOnly(true);
+        return cookie;
     }
 }

--- a/server/collusic-be/src/main/java/com/collusic/collusicbe/web/controller/MemberController.java
+++ b/server/collusic-be/src/main/java/com/collusic/collusicbe/web/controller/MemberController.java
@@ -59,7 +59,7 @@ public class MemberController {
     private Cookie setCookieWithRefreshToken(String refreshToken) {
         Cookie cookie = new Cookie("refreshToken", refreshToken);
         cookie.setMaxAge(REFRESH_TIME);
-        cookie.setSecure(true);
+        cookie.setSecure(false); // TODO : HTTPS 적용 시 true로 옵션 변경하기
         cookie.setHttpOnly(true);
         return cookie;
     }

--- a/server/collusic-be/src/main/java/com/collusic/collusicbe/web/controller/dto/SignUpResponseDto.java
+++ b/server/collusic-be/src/main/java/com/collusic/collusicbe/web/controller/dto/SignUpResponseDto.java
@@ -15,7 +15,7 @@ public class SignUpResponseDto {
 
     @Builder
     public SignUpResponseDto(OAuth2LoginResponseType responseType, String message,
-                             String accessToken, String refreshToken, String email) {
+                             String accessToken, String email) {
         this.responseType = responseType;
 
         attributes = new HashMap<>();
@@ -24,9 +24,6 @@ public class SignUpResponseDto {
         }
         if (accessToken != null) {
             attributes.put("accessToken", accessToken);
-        }
-        if (refreshToken != null) {
-            attributes.put("refreshToken", refreshToken);
         }
         if (email != null) {
             attributes.put("email", email);


### PR DESCRIPTION
## 구현 기능 
* 리프레시 토큰을 HttpOnly 방식으로 쿠키에 담아 응답하기

## 공유하고 싶은 내용 
https://dncjf64.tistory.com/292

    
Close #199 
