### PR TITLE
[Refactor/208]: 프로필 이미지 업로드 api 변경사항 반영

### DIFF
--- a/server/collusic-be/src/main/java/com/collusic/collusicbe/service/MemberService.java
+++ b/server/collusic-be/src/main/java/com/collusic/collusicbe/service/MemberService.java
@@ -12,6 +12,7 @@ import org.springframework.web.multipart.MultipartFile;
 
 import java.io.IOException;
 import java.util.List;
+import java.util.Map;
 import java.util.Optional;
 
 @RequiredArgsConstructor
@@ -34,7 +35,7 @@ public class MemberService {
         }
     }
 
-    public String uploadProfile(String nickname, @ModelAttribute MultipartFile multipartFile) throws IOException {
+    public Map<String, String> uploadProfile(String nickname, @ModelAttribute MultipartFile multipartFile) throws IOException {
         return s3Service.upload(nickname, multipartFile);
     }
 

--- a/server/collusic-be/src/main/java/com/collusic/collusicbe/service/S3Service.java
+++ b/server/collusic-be/src/main/java/com/collusic/collusicbe/service/S3Service.java
@@ -38,10 +38,6 @@ public class S3Service {
         StringBuilder newFileKey = new StringBuilder();
 
         newFileKey.append(nickname)
-                  .append("-")
-                  .append(getContentType(multipartFile.getOriginalFilename()))
-                  .append("-")
-                  .append(time)
                   .append(".png");
 
         ObjectMetadata objectMetadata = new ObjectMetadata();

--- a/server/collusic-be/src/main/java/com/collusic/collusicbe/service/S3Service.java
+++ b/server/collusic-be/src/main/java/com/collusic/collusicbe/service/S3Service.java
@@ -14,8 +14,8 @@ import org.springframework.web.multipart.MultipartFile;
 import java.io.File;
 import java.io.FileOutputStream;
 import java.io.IOException;
-import java.time.LocalDateTime;
-import java.time.format.DateTimeFormatter;
+import java.util.HashMap;
+import java.util.Map;
 import java.util.Optional;
 
 @Slf4j
@@ -33,10 +33,8 @@ public class S3Service {
     @Value("${cloud.aws.cloudfront.domain}")
     private String cloudFrontDomain;
 
-    public String upload(String nickname, @ModelAttribute MultipartFile multipartFile) throws IOException {
-        String time = LocalDateTime.now().format(DateTimeFormatter.ofPattern("yyyyMMddHHmmss"));
+    public Map<String, String> upload(String nickname, @ModelAttribute MultipartFile multipartFile) throws IOException {
         StringBuilder newFileKey = new StringBuilder();
-
         newFileKey.append(nickname)
                   .append(".png");
 
@@ -47,7 +45,11 @@ public class S3Service {
         s3Client.putObject(new PutObjectRequest(bucket, IMAGE_DIR + "/" + newFileKey, multipartFile.getInputStream(), objectMetadata)
                 .withCannedAcl(CannedAccessControlList.PublicRead));
 
-        return cloudFrontDomain + "/profiles/" + newFileKey;
+        Map<String, String> profileUrls = new HashMap<>();
+        profileUrls.put("originalProfileUrl", cloudFrontDomain + "/profiles/" + newFileKey);
+        profileUrls.put("resizedProfileUrl", cloudFrontDomain + "/resized-profiles/" + newFileKey);
+
+        return profileUrls;
     }
 
     public String upload(@ModelAttribute MultipartFile multipartFile, String dirName) throws IOException {

--- a/server/collusic-be/src/main/java/com/collusic/collusicbe/web/controller/dto/ProfileUploadResponseDto.java
+++ b/server/collusic-be/src/main/java/com/collusic/collusicbe/web/controller/dto/ProfileUploadResponseDto.java
@@ -1,0 +1,15 @@
+package com.collusic.collusicbe.web.controller.dto;
+
+import lombok.Getter;
+
+@Getter
+public class ProfileUploadResponseDto {
+
+    private final String originalProfileUrl;
+    private final String resizedProfileUrl;
+
+    public ProfileUploadResponseDto(String originalProfileUrl, String resizedProfileUrl) {
+        this.originalProfileUrl = originalProfileUrl;
+        this.resizedProfileUrl = resizedProfileUrl;
+    }
+}


### PR DESCRIPTION
## 구현 기능 
- cloudfront에 원본 s3 버킷과 리사이징 s3 버킷 둘다 적용되도록 설정
- api 응답 바디에 원본 이미지 url과 리사이징 이미지 url 담기도록 변경
- api 요청할 때마다 기존 사용자 프로필 이미지 버킷에서 덮어쓰도록 변경

## 논의하고 싶은 내용 (optional)
빠른 시간 안에 해결해 다음 스프린트에 지장없이 진행할 수 있다면 아래 사항들을 추가적으로 고민하고 반영하고자 합니다.
- 기존 이미지를 덮어쓰는 것이 아닌 제거하도록 변경. 파일명은 {nickname}_{타임스탬프}.png가 될 수 있도록
- 기존 이미지 url 추가 및 default 적용
- 기존 이미지로 초기화 api 구현
- member 테이블에 resized profile url 컬럼을 추가할 것인지 논의 후 반영
- rest 관점에서 post에서 url을 응답하는게 맞을지 논의 후 반영

    
Close #208 
