### PR TITLE
feat/207 : 리프레시 토큰을 통한 액세스 토큰 재발급 기능 추가

### DIFF
--- a/server/collusic-be/src/main/java/com/collusic/collusicbe/config/SecurityConfig.java
+++ b/server/collusic-be/src/main/java/com/collusic/collusicbe/config/SecurityConfig.java
@@ -2,6 +2,8 @@ package com.collusic.collusicbe.config;
 
 import com.collusic.collusicbe.config.auth.JWTAuthenticationFilter;
 import com.collusic.collusicbe.config.auth.JWTAuthenticationProvider;
+import com.collusic.collusicbe.service.TokenService;
+import com.fasterxml.jackson.databind.ObjectMapper;
 import lombok.RequiredArgsConstructor;
 import org.springframework.boot.autoconfigure.security.servlet.PathRequest;
 import org.springframework.context.annotation.Bean;
@@ -22,6 +24,8 @@ import org.springframework.web.cors.UrlBasedCorsConfigurationSource;
 public class SecurityConfig extends WebSecurityConfigurerAdapter {
 
     private final JWTAuthenticationProvider jwtAuthenticationProvider;
+    private final TokenService tokenService;
+    private final ObjectMapper objectMapper;
 
     @Override
     protected void configure(HttpSecurity http) throws Exception {
@@ -34,7 +38,7 @@ public class SecurityConfig extends WebSecurityConfigurerAdapter {
                                                      .antMatchers("/swagger-ui/**", "/swagger-resources/**", "/v3/api-docs").permitAll()
                                                      .antMatchers(HttpMethod.OPTIONS, "/**").permitAll()
                                                      .anyRequest().authenticated())
-                .addFilterAt(new JWTAuthenticationFilter(authenticationManager()), BasicAuthenticationFilter.class);
+                .addFilterAt(new JWTAuthenticationFilter(authenticationManager(), tokenService, objectMapper), BasicAuthenticationFilter.class);
     }
 
     @Bean

--- a/server/collusic-be/src/main/java/com/collusic/collusicbe/config/auth/ExceptionHandlerFilter.java
+++ b/server/collusic-be/src/main/java/com/collusic/collusicbe/config/auth/ExceptionHandlerFilter.java
@@ -1,0 +1,41 @@
+package com.collusic.collusicbe.config.auth;
+
+import com.collusic.collusicbe.global.exception.ExceptionInfoResponse;
+import com.collusic.collusicbe.global.exception.jwt.AbnormalAccessException;
+import com.collusic.collusicbe.global.exception.jwt.ExpiredJwtException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+import org.springframework.stereotype.Component;
+import org.springframework.web.filter.OncePerRequestFilter;
+
+import javax.persistence.EntityNotFoundException;
+import javax.servlet.FilterChain;
+import javax.servlet.ServletException;
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+import java.io.IOException;
+
+@Component
+@RequiredArgsConstructor
+public class ExceptionHandlerFilter extends OncePerRequestFilter {
+
+    private final ObjectMapper objectMapper;
+
+    @Override
+    protected void doFilterInternal(HttpServletRequest request, HttpServletResponse response, FilterChain filterChain) throws ServletException, IOException {
+
+        try {
+            filterChain.doFilter(request, response);
+        } catch (ExpiredJwtException | AbnormalAccessException | EntityNotFoundException e) {
+            sendErrorResponse(HttpStatus.UNAUTHORIZED.value(), response, e);
+        }
+    }
+
+    private void sendErrorResponse(int status, HttpServletResponse response, RuntimeException e) throws IOException {
+        response.setCharacterEncoding("UTF-8");
+        response.setContentType("application/json");
+        response.setStatus(status);
+        response.getWriter().write(objectMapper.writeValueAsString(ExceptionInfoResponse.from(HttpStatus.UNAUTHORIZED.getReasonPhrase(), e.getMessage())));
+    }
+}

--- a/server/collusic-be/src/main/java/com/collusic/collusicbe/config/auth/JWTAuthenticationFilter.java
+++ b/server/collusic-be/src/main/java/com/collusic/collusicbe/config/auth/JWTAuthenticationFilter.java
@@ -1,6 +1,11 @@
 package com.collusic.collusicbe.config.auth;
 
+import com.collusic.collusicbe.global.exception.jwt.AbnormalAccessException;
+import com.collusic.collusicbe.service.TokenService;
 import com.collusic.collusicbe.util.JWTUtil;
+import com.collusic.collusicbe.util.ParsingUtil;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import io.jsonwebtoken.ExpiredJwtException;
 import org.springframework.http.HttpHeaders;
 import org.springframework.security.authentication.AuthenticationManager;
 import org.springframework.security.core.Authentication;
@@ -8,11 +13,15 @@ import org.springframework.security.core.authority.SimpleGrantedAuthority;
 import org.springframework.security.core.context.SecurityContextHolder;
 import org.springframework.security.web.authentication.www.BasicAuthenticationFilter;
 
+import javax.persistence.EntityNotFoundException;
 import javax.servlet.FilterChain;
 import javax.servlet.ServletException;
+import javax.servlet.http.Cookie;
 import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
 import java.io.IOException;
+import java.util.Arrays;
+import java.util.NoSuchElementException;
 import java.util.Set;
 
 public class JWTAuthenticationFilter extends BasicAuthenticationFilter {
@@ -21,9 +30,15 @@ public class JWTAuthenticationFilter extends BasicAuthenticationFilter {
 
     private final AuthenticationManager authenticationManager;
 
-    public JWTAuthenticationFilter(AuthenticationManager authenticationManager) {
+    private final TokenService tokenService;
+
+    private final ObjectMapper objectMapper;
+
+    public JWTAuthenticationFilter(AuthenticationManager authenticationManager, TokenService tokenService, ObjectMapper objectMapper) {
         super(authenticationManager);
         this.authenticationManager = authenticationManager;
+        this.tokenService = tokenService;
+        this.objectMapper = objectMapper;
     }
 
     @Override
@@ -38,12 +53,51 @@ public class JWTAuthenticationFilter extends BasicAuthenticationFilter {
 
         String token = bearer.substring(BEARER_PREFIX.length());
 
-        JWTAuthenticationToken authenticationToken = new JWTAuthenticationToken(token, Set.of(new SimpleGrantedAuthority(JWTUtil.getRole(token)))); // TODO: JWT 형식이 아닌 토큰이 들어왔을 때 예외가 예상되는 부분. 해결이 필요함.
-        Authentication authentication = this.authenticationManager.authenticate(authenticationToken);
+        try {
+            JWTAuthenticationToken authenticationToken = new JWTAuthenticationToken(token, Set.of(new SimpleGrantedAuthority(JWTUtil.getRole(token)))); // TODO: JWT 형식이 아닌 토큰이 들어왔을 때 예외가 예상되는 부분. 해결이 필요함.
+            Authentication authentication = this.authenticationManager.authenticate(authenticationToken);
 
-        SecurityContextHolder.getContext()
-                             .setAuthentication(authentication);
+            SecurityContextHolder.getContext()
+                                 .setAuthentication(authentication);
 
-        chain.doFilter(request, response);
+            chain.doFilter(request, response);
+        } catch (ExpiredJwtException e) {
+            token = reissueAccessToken(request, response);
+
+            JWTAuthenticationToken authenticationToken = new JWTAuthenticationToken(token, Set.of(new SimpleGrantedAuthority(JWTUtil.getRole(token)))); // TODO: JWT 형식이 아닌 토큰이 들어왔을 때 예외가 예상되는 부분. 해결이 필요함.
+            Authentication authentication = this.authenticationManager.authenticate(authenticationToken);
+
+            SecurityContextHolder.getContext()
+                                 .setAuthentication(authentication);
+
+            chain.doFilter(request, response);
+        }
+    }
+
+    private String reissueAccessToken(HttpServletRequest request, HttpServletResponse response) {
+
+        Cookie[] cookies = request.getCookies();
+
+        Cookie cookie = Arrays.stream(cookies)
+                              .filter(c -> c.getName().equals("refreshToken"))
+                              .findFirst()
+                              .orElseThrow(NoSuchElementException::new); // TODO : NoSuch에 대한 예외 처리하기
+
+        String refreshToken = cookie.getValue();
+
+        try {
+            JWTUtil.verify(refreshToken);
+
+            String accessToken = tokenService.reissueAccessToken(refreshToken, ParsingUtil.getRemoteAddress(request));
+            response.setHeader("Authorization", BEARER_PREFIX + accessToken);
+
+            return accessToken;
+        } catch (ExpiredJwtException | EntityNotFoundException e) {
+            throw e;
+        } catch (AbnormalAccessException e) {
+            tokenService.deleteRefreshToken(refreshToken);
+            throw e;
+        }
+
     }
 }

--- a/server/collusic-be/src/main/java/com/collusic/collusicbe/config/auth/JWTAuthenticationProvider.java
+++ b/server/collusic-be/src/main/java/com/collusic/collusicbe/config/auth/JWTAuthenticationProvider.java
@@ -1,5 +1,5 @@
 package com.collusic.collusicbe.config.auth;
-
+import com.collusic.collusicbe.global.exception.jwt.ExpiredJwtException;
 import com.collusic.collusicbe.util.JWTUtil;
 import org.springframework.security.authentication.AuthenticationProvider;
 import org.springframework.security.core.Authentication;
@@ -10,7 +10,7 @@ import org.springframework.stereotype.Component;
 public class JWTAuthenticationProvider implements AuthenticationProvider {
 
     @Override
-    public Authentication authenticate(Authentication authentication) throws AuthenticationException {
+    public Authentication authenticate(Authentication authentication) throws AuthenticationException, ExpiredJwtException {
         String token = (String) authentication.getPrincipal();
 
         JWTUtil.verify(token);

--- a/server/collusic-be/src/main/java/com/collusic/collusicbe/global/exception/ExceptionInfoResponse.java
+++ b/server/collusic-be/src/main/java/com/collusic/collusicbe/global/exception/ExceptionInfoResponse.java
@@ -9,4 +9,8 @@ public class ExceptionInfoResponse {
 
     private final String status;
     private final String message;
+
+    public static ExceptionInfoResponse from(String status, String message) {
+        return new ExceptionInfoResponse(status, message);
+    }
 }

--- a/server/collusic-be/src/main/java/com/collusic/collusicbe/global/exception/jwt/AbnormalAccessException.java
+++ b/server/collusic-be/src/main/java/com/collusic/collusicbe/global/exception/jwt/AbnormalAccessException.java
@@ -1,0 +1,8 @@
+package com.collusic.collusicbe.global.exception.jwt;
+
+public class AbnormalAccessException extends RuntimeException {
+
+    public AbnormalAccessException(String message) {
+        super(message);
+    }
+}

--- a/server/collusic-be/src/main/java/com/collusic/collusicbe/global/exception/jwt/ExpiredJwtException.java
+++ b/server/collusic-be/src/main/java/com/collusic/collusicbe/global/exception/jwt/ExpiredJwtException.java
@@ -1,0 +1,10 @@
+package com.collusic.collusicbe.global.exception.jwt;
+
+import io.jsonwebtoken.JwtException;
+
+public class ExpiredJwtException extends JwtException {
+
+    public ExpiredJwtException(String message) {
+        super(message);
+    }
+}

--- a/server/collusic-be/src/main/java/com/collusic/collusicbe/service/TokenService.java
+++ b/server/collusic-be/src/main/java/com/collusic/collusicbe/service/TokenService.java
@@ -1,10 +1,12 @@
 package com.collusic.collusicbe.service;
 
+import com.collusic.collusicbe.global.exception.jwt.AbnormalAccessException;
 import com.collusic.collusicbe.util.JWTUtil;
 import com.collusic.collusicbe.web.controller.dto.TokenResponseDto;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 
+import javax.persistence.EntityNotFoundException;
 import java.time.Duration;
 
 import static com.collusic.collusicbe.util.JWTUtil.REFRESH_TIME;
@@ -35,11 +37,11 @@ public class TokenService {
     private String reissueAccessToken(String refreshToken, String remoteAddress) {
 
         if (!redisRepository.hasKey(refreshToken)) {
-            throw new RuntimeException("사용할 수 없는 토큰");
+            throw new EntityNotFoundException("토큰이 존재하지 않습니다.");
         }
 
-        if (redisRepository.findByKey(refreshToken).equals(remoteAddress)) {
-            throw new RuntimeException("ip 주소가 다름"); // TODO: 비정상적인 접근으로 redis에서 refreshtoken을 지워줘야함
+        if (!redisRepository.findByKey(refreshToken).equals(remoteAddress)) {
+            throw new AbnormalAccessException("사용자의 IP 주소가 다릅니다."); // TODO: 비정상적인 접근으로 redis에서 refreshtoken을 지워줘야함
         }
 
         String email = JWTUtil.getEmail(refreshToken);

--- a/server/collusic-be/src/main/java/com/collusic/collusicbe/service/TokenService.java
+++ b/server/collusic-be/src/main/java/com/collusic/collusicbe/service/TokenService.java
@@ -34,6 +34,10 @@ public class TokenService {
         return new TokenResponseDto(accessToken, refreshToken);
     }
 
+    public void deleteRefreshToken(String refreshToken) {
+        redisRepository.delete(refreshToken);
+    }
+
     private String reissueAccessToken(String refreshToken, String remoteAddress) {
 
         if (!redisRepository.hasKey(refreshToken)) {

--- a/server/collusic-be/src/main/java/com/collusic/collusicbe/service/TokenService.java
+++ b/server/collusic-be/src/main/java/com/collusic/collusicbe/service/TokenService.java
@@ -38,7 +38,7 @@ public class TokenService {
         redisRepository.delete(refreshToken);
     }
 
-    private String reissueAccessToken(String refreshToken, String remoteAddress) {
+    public String reissueAccessToken(String refreshToken, String remoteAddress) {
 
         if (!redisRepository.hasKey(refreshToken)) {
             throw new EntityNotFoundException("토큰이 존재하지 않습니다.");

--- a/server/collusic-be/src/main/java/com/collusic/collusicbe/util/JWTUtil.java
+++ b/server/collusic-be/src/main/java/com/collusic/collusicbe/util/JWTUtil.java
@@ -2,15 +2,16 @@ package com.collusic.collusicbe.util;
 
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
-import io.jsonwebtoken.Claims;
-import io.jsonwebtoken.Jwts;
-import io.jsonwebtoken.SignatureAlgorithm;
+import io.jsonwebtoken.*;
+import com.collusic.collusicbe.global.exception.jwt.ExpiredJwtException;
+import lombok.extern.slf4j.Slf4j;
 
 import java.time.Instant;
 import java.util.Base64;
 import java.util.HashMap;
 import java.util.Map;
 
+@Slf4j
 public class JWTUtil {
 
     private static final int ACCESS_TIME = 60 * 60;
@@ -33,8 +34,21 @@ public class JWTUtil {
                        .setSigningKey(KEY)
                        .parseClaimsJws(token)
                        .getBody();
-        } catch (Exception exception) {
-            throw new RuntimeException("토큰 만료"); // TODO : 어떤 에러 메시지를 보낼 것인가?
+        } catch (ExpiredJwtException e) {
+            log.info("토큰 만료");
+            throw new ExpiredJwtException("토큰 만료");
+        } catch (UnsupportedJwtException e) {
+            log.info("애플리케이션에서 지원하지 않는 토큰 형식");
+            throw new UnsupportedJwtException("애플리케이션에서 지원하지 않는 토큰 형식");
+        } catch (MalformedJwtException e) {
+            log.info("구조적인 문제가 있는 토큰");
+            throw new MalformedJwtException("구조적인 문제가 있는 토큰");
+        } catch (SignatureException e) {
+            log.info("시그니처 검증 실패");
+            throw new SignatureException("시그니처 검증 실패");
+        } catch (IllegalArgumentException e) {
+            log.info("부적합한 인수");
+            throw new IllegalArgumentException("부적합한 인수");
         }
     }
 


### PR DESCRIPTION
## 구현 기능 
* 액세스 토큰 만료 시 리프레시 토큰 검증을 위한 액세스 토큰 재발급
* 리프레시 토큰 검증
* Redis 저장소에서 요청 IP와 저장된 IP의 동일 여부 확인하고 리프레시 토큰의 탈취 상황인 경우 리프레시 토큰 Redis 저장소에서 제거 


## 논의하고 싶은 내용
* 로직 개선


## 공유하고 싶은 내용
* 토큰 만료 예외의 경우만을 가정한 구현(UnsupportedJwtException, MalformedJwtException와 같은 JWT 토큰 검증 예외 핸들링은 추가되지 않음.)

    
Close #207 