### PR TITLE
Feat/229: 트랙 CRUD API 구현 완료

### DIFF
--- a/server/collusic-be/src/main/java/com/collusic/collusicbe/config/SecurityConfig.java
+++ b/server/collusic-be/src/main/java/com/collusic/collusicbe/config/SecurityConfig.java
@@ -3,6 +3,7 @@ package com.collusic.collusicbe.config;
 import com.collusic.collusicbe.config.auth.ExceptionHandlerFilter;
 import com.collusic.collusicbe.config.auth.JWTAuthenticationFilter;
 import com.collusic.collusicbe.config.auth.JWTAuthenticationProvider;
+import com.collusic.collusicbe.config.auth.JwtAuthenticationEntryPoint;
 import com.collusic.collusicbe.service.TokenService;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import lombok.RequiredArgsConstructor;
@@ -15,6 +16,8 @@ import org.springframework.security.config.annotation.web.builders.WebSecurity;
 import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
 import org.springframework.security.config.annotation.web.configuration.WebSecurityConfigurerAdapter;
 import org.springframework.security.config.http.SessionCreationPolicy;
+import org.springframework.security.web.AuthenticationEntryPoint;
+import org.springframework.security.web.authentication.UsernamePasswordAuthenticationFilter;
 import org.springframework.security.web.authentication.www.BasicAuthenticationFilter;
 import org.springframework.web.cors.CorsConfiguration;
 import org.springframework.web.cors.CorsConfigurationSource;
@@ -25,6 +28,7 @@ import org.springframework.web.cors.UrlBasedCorsConfigurationSource;
 public class SecurityConfig extends WebSecurityConfigurerAdapter {
 
     private final JWTAuthenticationProvider jwtAuthenticationProvider;
+    private final AuthenticationEntryPoint jwtAuthenticationEntryPoint;
     private final TokenService tokenService;
     private final ObjectMapper objectMapper;
     private final ExceptionHandlerFilter exceptionHandlerFilter;
@@ -40,6 +44,7 @@ public class SecurityConfig extends WebSecurityConfigurerAdapter {
                                                      .antMatchers("/swagger-ui/**", "/swagger-resources/**", "/v3/api-docs").permitAll()
                                                      .antMatchers(HttpMethod.OPTIONS, "/**").permitAll()
                                                      .anyRequest().authenticated())
+                .exceptionHandling().authenticationEntryPoint(jwtAuthenticationEntryPoint).and()
                 .addFilterAt(new JWTAuthenticationFilter(authenticationManager(), tokenService, objectMapper), BasicAuthenticationFilter.class)
                 .addFilterBefore(exceptionHandlerFilter, JWTAuthenticationFilter.class);
     }

--- a/server/collusic-be/src/main/java/com/collusic/collusicbe/config/SecurityConfig.java
+++ b/server/collusic-be/src/main/java/com/collusic/collusicbe/config/SecurityConfig.java
@@ -3,7 +3,6 @@ package com.collusic.collusicbe.config;
 import com.collusic.collusicbe.config.auth.ExceptionHandlerFilter;
 import com.collusic.collusicbe.config.auth.JWTAuthenticationFilter;
 import com.collusic.collusicbe.config.auth.JWTAuthenticationProvider;
-import com.collusic.collusicbe.config.auth.JwtAuthenticationEntryPoint;
 import com.collusic.collusicbe.service.TokenService;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import lombok.RequiredArgsConstructor;
@@ -17,7 +16,6 @@ import org.springframework.security.config.annotation.web.configuration.EnableWe
 import org.springframework.security.config.annotation.web.configuration.WebSecurityConfigurerAdapter;
 import org.springframework.security.config.http.SessionCreationPolicy;
 import org.springframework.security.web.AuthenticationEntryPoint;
-import org.springframework.security.web.authentication.UsernamePasswordAuthenticationFilter;
 import org.springframework.security.web.authentication.www.BasicAuthenticationFilter;
 import org.springframework.web.cors.CorsConfiguration;
 import org.springframework.web.cors.CorsConfigurationSource;
@@ -42,6 +40,7 @@ public class SecurityConfig extends WebSecurityConfigurerAdapter {
                 .authorizeRequests(request -> request.antMatchers(HttpMethod.POST, "/members").permitAll()
                                                      .antMatchers(HttpMethod.GET, "/oauth2/login/**", "/members/{nickname}").permitAll()
                                                      .antMatchers("/swagger-ui/**", "/swagger-resources/**", "/v3/api-docs").permitAll()
+                                                     .antMatchers(HttpMethod.GET, "/projects/**").permitAll()
                                                      .antMatchers(HttpMethod.OPTIONS, "/**").permitAll()
                                                      .anyRequest().authenticated())
                 .exceptionHandling().authenticationEntryPoint(jwtAuthenticationEntryPoint).and()

--- a/server/collusic-be/src/main/java/com/collusic/collusicbe/config/auth/ExceptionHandlerFilter.java
+++ b/server/collusic-be/src/main/java/com/collusic/collusicbe/config/auth/ExceptionHandlerFilter.java
@@ -1,6 +1,7 @@
 package com.collusic.collusicbe.config.auth;
 
 import com.collusic.collusicbe.global.exception.ExceptionInfoResponse;
+import com.collusic.collusicbe.global.exception.UnAuthorizedException;
 import com.collusic.collusicbe.global.exception.jwt.AbnormalAccessException;
 import com.collusic.collusicbe.global.exception.jwt.ExpiredJwtException;
 import com.fasterxml.jackson.databind.ObjectMapper;
@@ -27,7 +28,7 @@ public class ExceptionHandlerFilter extends OncePerRequestFilter {
 
         try {
             filterChain.doFilter(request, response);
-        } catch (ExpiredJwtException | AbnormalAccessException | EntityNotFoundException e) {
+        } catch (ExpiredJwtException | AbnormalAccessException | EntityNotFoundException | UnAuthorizedException e) {
             sendErrorResponse(HttpStatus.UNAUTHORIZED.value(), response, e);
         }
     }

--- a/server/collusic-be/src/main/java/com/collusic/collusicbe/config/auth/JWTAuthenticationFilter.java
+++ b/server/collusic-be/src/main/java/com/collusic/collusicbe/config/auth/JWTAuthenticationFilter.java
@@ -1,5 +1,6 @@
 package com.collusic.collusicbe.config.auth;
 
+import com.collusic.collusicbe.global.exception.UnAuthorizedException;
 import com.collusic.collusicbe.global.exception.jwt.AbnormalAccessException;
 import com.collusic.collusicbe.service.TokenService;
 import com.collusic.collusicbe.util.JWTUtil;
@@ -21,7 +22,7 @@ import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
 import java.io.IOException;
 import java.util.Arrays;
-import java.util.NoSuchElementException;
+import java.util.Optional;
 import java.util.Set;
 
 public class JWTAuthenticationFilter extends BasicAuthenticationFilter {
@@ -76,12 +77,15 @@ public class JWTAuthenticationFilter extends BasicAuthenticationFilter {
 
     private String reissueAccessToken(HttpServletRequest request, HttpServletResponse response) {
 
-        Cookie[] cookies = request.getCookies();
+        Cookie[] cookies = Optional.ofNullable(request.getCookies())
+                                   .orElseGet(() -> new Cookie[]{});
 
-        Cookie cookie = Arrays.stream(cookies)
-                              .filter(c -> c.getName().equals("refreshToken"))
-                              .findFirst()
-                              .orElseThrow(NoSuchElementException::new); // TODO : NoSuch에 대한 예외 처리하기
+        Cookie cookie; // TODO : NoSuch에 대한 예외 처리하기
+
+        cookie = Arrays.stream(cookies)
+                       .filter(c -> c.getName().equals("refreshToken"))
+                       .findFirst()
+                       .orElseThrow(UnAuthorizedException::new);
 
         String refreshToken = cookie.getValue();
 

--- a/server/collusic-be/src/main/java/com/collusic/collusicbe/config/auth/JwtAuthenticationEntryPoint.java
+++ b/server/collusic-be/src/main/java/com/collusic/collusicbe/config/auth/JwtAuthenticationEntryPoint.java
@@ -1,0 +1,26 @@
+package com.collusic.collusicbe.config.auth;
+
+import com.collusic.collusicbe.global.exception.ExceptionInfoResponse;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.springframework.http.HttpStatus;
+import org.springframework.security.core.AuthenticationException;
+import org.springframework.security.web.AuthenticationEntryPoint;
+import org.springframework.stereotype.Component;
+
+import javax.servlet.ServletException;
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+import java.io.IOException;
+
+@Component
+public class JwtAuthenticationEntryPoint implements AuthenticationEntryPoint {
+    @Override
+    public void commence(HttpServletRequest request, HttpServletResponse response, AuthenticationException e) throws IOException, ServletException {
+        ObjectMapper objectMapper = new ObjectMapper();
+
+        response.setCharacterEncoding("UTF-8");
+        response.setContentType("application/json");
+        response.setStatus(HttpStatus.UNAUTHORIZED.value());
+        response.getWriter().write(objectMapper.writeValueAsString(ExceptionInfoResponse.from(HttpStatus.UNAUTHORIZED.getReasonPhrase(), e.getMessage())));
+    }
+}

--- a/server/collusic-be/src/main/java/com/collusic/collusicbe/domain/member/Member.java
+++ b/server/collusic-be/src/main/java/com/collusic/collusicbe/domain/member/Member.java
@@ -57,4 +57,8 @@ public class Member extends BaseTimeEntity {
     public void updateProfile(String profileImageUrl) {
         this.profileImageUrl = profileImageUrl;
     }
+
+    public boolean isSameMember(String nickname) {
+        return this.nickname.equals(nickname);
+    }
 }

--- a/server/collusic-be/src/main/java/com/collusic/collusicbe/domain/member/Member.java
+++ b/server/collusic-be/src/main/java/com/collusic/collusicbe/domain/member/Member.java
@@ -15,7 +15,8 @@ import javax.validation.constraints.Size;
 public class Member extends BaseTimeEntity {
 
     @Builder
-    public Member(String authId, String email, String nickname, String profileImageUrl, SnsType snsType, Role role) {
+    public Member(Long id, String authId, String email, String nickname, String profileImageUrl, SnsType snsType, Role role) {
+        this.id = id;
         this.authId = authId;
         this.email = email;
         this.nickname = nickname;
@@ -58,7 +59,7 @@ public class Member extends BaseTimeEntity {
         this.profileImageUrl = profileImageUrl;
     }
 
-    public boolean isSameMember(String nickname) {
-        return this.nickname.equals(nickname);
+    public boolean isSameMember(Member member) {
+        return this.id.equals(member.getId());
     }
 }

--- a/server/collusic-be/src/main/java/com/collusic/collusicbe/domain/project/Project.java
+++ b/server/collusic-be/src/main/java/com/collusic/collusicbe/domain/project/Project.java
@@ -14,6 +14,7 @@ import javax.validation.constraints.Min;
 import javax.validation.constraints.Size;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.NoSuchElementException;
 
 @Entity
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
@@ -68,5 +69,25 @@ public class Project extends BaseTimeEntity {
 
     public boolean isLastTrackId(Long trackId) {
         return tracks.get(tracks.size() - 1).getId().equals(trackId);
+    }
+
+    public void addTrack(Track track) {
+        this.tracks.add(track);
+    }
+
+    public Track getTrack(long trackId) {
+        return tracks.stream()
+                     .filter(track -> track.getId().equals(trackId))
+                     .findFirst()
+                     .orElseThrow(NoSuchElementException::new);
+    }
+
+    public void removeTrack(int order) {
+        tracks.remove(order);
+
+        for (int i = order; i < tracks.size(); i++) {
+            Track track = tracks.get(i);
+            track.changeOrder(i);
+        }
     }
 }

--- a/server/collusic-be/src/main/java/com/collusic/collusicbe/domain/project/Project.java
+++ b/server/collusic-be/src/main/java/com/collusic/collusicbe/domain/project/Project.java
@@ -13,6 +13,7 @@ import javax.validation.constraints.Max;
 import javax.validation.constraints.Min;
 import javax.validation.constraints.Size;
 import java.util.ArrayList;
+import java.util.Comparator;
 import java.util.List;
 import java.util.NoSuchElementException;
 
@@ -47,13 +48,12 @@ public class Project extends BaseTimeEntity {
     private static final int MAX_TRACK_CAPACITY = 10;
 
     @Builder
-    public Project(Long id, String projectName, int bpm, String fileUrl, State projectState, List<Track> tracks) {
+    public Project(Long id, String projectName, int bpm, String fileUrl, State projectState) {
         this.id = id;
         this.projectName = projectName;
         this.bpm = bpm;
         this.fileUrl = fileUrl;
         this.projectState = projectState;
-        this.tracks = tracks;
     }
 
     public boolean isTrackFull() {
@@ -76,17 +76,24 @@ public class Project extends BaseTimeEntity {
     }
 
     public Track getTrack(long trackId) {
+        this.tracks.sort(Comparator.comparingInt(Track::getOrderInProject));
+
         return tracks.stream()
                      .filter(track -> track.getId().equals(trackId))
                      .findFirst()
                      .orElseThrow(NoSuchElementException::new);
     }
 
-    public void removeTrack(int order) {
-        tracks.remove(order);
+    public void removeTrack(long trackId) {
+        Track track = tracks.stream()
+                            .filter(t -> t.getId().equals(trackId))
+                            .findFirst()
+                            .orElseThrow(NoSuchElementException::new);
 
-        for (int i = order; i < tracks.size(); i++) {
-            Track track = tracks.get(i);
+        tracks.remove(track);
+
+        for (int i = 0; i < tracks.size(); i++) {
+            track = tracks.get(i);
             track.changeOrder(i);
         }
     }

--- a/server/collusic-be/src/main/java/com/collusic/collusicbe/domain/project/Project.java
+++ b/server/collusic-be/src/main/java/com/collusic/collusicbe/domain/project/Project.java
@@ -42,6 +42,8 @@ public class Project extends BaseTimeEntity {
     @OneToMany(mappedBy = "project", cascade = CascadeType.ALL)
     private List<Track> tracks;
 
+    private static final int MAX_TRACK_CAPACITY = 10;
+
     @Builder
     public Project(Long id, String projectName, int bpm, String fileUrl, State projectState, List<Track> tracks) {
         this.id = id;
@@ -53,7 +55,7 @@ public class Project extends BaseTimeEntity {
     }
 
     public boolean isTrackFull() {
-        return tracks.size() == 10;
+        return tracks.size() == MAX_TRACK_CAPACITY;
     }
 
     public int getNextTrackOrder() {

--- a/server/collusic-be/src/main/java/com/collusic/collusicbe/domain/project/Project.java
+++ b/server/collusic-be/src/main/java/com/collusic/collusicbe/domain/project/Project.java
@@ -12,6 +12,7 @@ import javax.persistence.*;
 import javax.validation.constraints.Max;
 import javax.validation.constraints.Min;
 import javax.validation.constraints.Size;
+import java.util.ArrayList;
 import java.util.List;
 
 @Entity
@@ -40,7 +41,7 @@ public class Project extends BaseTimeEntity {
     private State projectState;
 
     @OneToMany(mappedBy = "project", cascade = CascadeType.ALL)
-    private List<Track> tracks;
+    private List<Track> tracks = new ArrayList<>();
 
     private static final int MAX_TRACK_CAPACITY = 10;
 
@@ -59,6 +60,13 @@ public class Project extends BaseTimeEntity {
     }
 
     public int getNextTrackOrder() {
+        if (tracks == null) {
+            return 0;
+        }
         return tracks.size();
+    }
+
+    public Track getLastTrack() {
+        return tracks.get(tracks.size() - 1);
     }
 }

--- a/server/collusic-be/src/main/java/com/collusic/collusicbe/domain/project/Project.java
+++ b/server/collusic-be/src/main/java/com/collusic/collusicbe/domain/project/Project.java
@@ -51,4 +51,12 @@ public class Project extends BaseTimeEntity {
         this.projectState = projectState;
         this.tracks = tracks;
     }
+
+    public boolean isTrackFull() {
+        return tracks.size() == 10;
+    }
+
+    public int getNextTrackOrder() {
+        return tracks.size();
+    }
 }

--- a/server/collusic-be/src/main/java/com/collusic/collusicbe/domain/project/Project.java
+++ b/server/collusic-be/src/main/java/com/collusic/collusicbe/domain/project/Project.java
@@ -2,7 +2,9 @@ package com.collusic.collusicbe.domain.project;
 
 import com.collusic.collusicbe.domain.BaseTimeEntity;
 import com.collusic.collusicbe.domain.state.State;
+import com.collusic.collusicbe.domain.track.Track;
 import lombok.AccessLevel;
+import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
@@ -10,6 +12,7 @@ import javax.persistence.*;
 import javax.validation.constraints.Max;
 import javax.validation.constraints.Min;
 import javax.validation.constraints.Size;
+import java.util.List;
 
 @Entity
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
@@ -35,4 +38,17 @@ public class Project extends BaseTimeEntity {
 
     @Enumerated(EnumType.STRING)
     private State projectState;
+
+    @OneToMany(mappedBy = "project", cascade = CascadeType.ALL)
+    private List<Track> tracks;
+
+    @Builder
+    public Project(Long id, String projectName, int bpm, String fileUrl, State projectState, List<Track> tracks) {
+        this.id = id;
+        this.projectName = projectName;
+        this.bpm = bpm;
+        this.fileUrl = fileUrl;
+        this.projectState = projectState;
+        this.tracks = tracks;
+    }
 }

--- a/server/collusic-be/src/main/java/com/collusic/collusicbe/domain/project/Project.java
+++ b/server/collusic-be/src/main/java/com/collusic/collusicbe/domain/project/Project.java
@@ -66,7 +66,7 @@ public class Project extends BaseTimeEntity {
         return tracks.size();
     }
 
-    public Track getLastTrack() {
-        return tracks.get(tracks.size() - 1);
+    public boolean isLastTrackId(Long trackId) {
+        return tracks.get(tracks.size() - 1).getId().equals(trackId);
     }
 }

--- a/server/collusic-be/src/main/java/com/collusic/collusicbe/domain/project/ProjectRepository.java
+++ b/server/collusic-be/src/main/java/com/collusic/collusicbe/domain/project/ProjectRepository.java
@@ -1,6 +1,13 @@
 package com.collusic.collusicbe.domain.project;
 
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+
+import java.util.Optional;
 
 public interface ProjectRepository extends JpaRepository<Project, Long> {
+
+    @Override
+    @Query("select p from Project p left join fetch p.tracks where p.id = :id")
+    Optional<Project> findById(Long id);
 }

--- a/server/collusic-be/src/main/java/com/collusic/collusicbe/domain/project/ProjectRepository.java
+++ b/server/collusic-be/src/main/java/com/collusic/collusicbe/domain/project/ProjectRepository.java
@@ -1,0 +1,6 @@
+package com.collusic.collusicbe.domain.project;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface ProjectRepository extends JpaRepository<Project, Long> {
+}

--- a/server/collusic-be/src/main/java/com/collusic/collusicbe/domain/track/Measure.java
+++ b/server/collusic-be/src/main/java/com/collusic/collusicbe/domain/track/Measure.java
@@ -1,13 +1,27 @@
 package com.collusic.collusicbe.domain.track;
 
+import com.fasterxml.jackson.annotation.JsonValue;
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+import java.util.Map;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
+
+@Getter
+@RequiredArgsConstructor
 public enum Measure {
     FOUR(4),
     EIGHT(8),
     SIXTEEN(16);
 
-    private int measure;
+    @JsonValue
+    private final int measure;
 
-    Measure(int measure) {
-        this.measure = measure;
+    private static final Map<Integer, Measure> integerToEnum =
+            Stream.of(values()).collect(Collectors.toMap(x -> x.measure, x -> x));
+
+    public static Measure valueOfInteger(Integer measure) {
+        return integerToEnum.get(measure);
     }
 }

--- a/server/collusic-be/src/main/java/com/collusic/collusicbe/domain/track/Track.java
+++ b/server/collusic-be/src/main/java/com/collusic/collusicbe/domain/track/Track.java
@@ -51,7 +51,8 @@ public class Track extends BaseTimeEntity {
     private int orderInProject;
 
     @Builder
-    public Track(String trackName, TrackTag trackTag, boolean editable, Member creator, Project project, Measure measure, int volume, int orderInProject) {
+    public Track(Long id, String trackName, TrackTag trackTag, boolean editable, Member creator, Project project, Measure measure, int volume, int orderInProject) {
+        this.id = id;
         this.trackName = trackName;
         this.trackTag = trackTag;
         this.editable = editable;
@@ -69,5 +70,9 @@ public class Track extends BaseTimeEntity {
         this.editable = editable;
         this.measure = measure;
         this.volume = volume;
+    }
+
+    public void changeOrder(int order) {
+        this.orderInProject = order;
     }
 }

--- a/server/collusic-be/src/main/java/com/collusic/collusicbe/domain/track/Track.java
+++ b/server/collusic-be/src/main/java/com/collusic/collusicbe/domain/track/Track.java
@@ -62,4 +62,12 @@ public class Track extends BaseTimeEntity {
         this.orderInProject = orderInProject;
         this.fileUrl = "empty"; // TODO : 음원 파일 데이터 시 추가 처리할 것
     }
+
+    public void changeTrackInfo(String trackName, TrackTag trackTag, boolean editable, Measure measure, int volume) {
+        this.trackName = trackName;
+        this.trackTag = trackTag;
+        this.editable = editable;
+        this.measure = measure;
+        this.volume = volume;
+    }
 }

--- a/server/collusic-be/src/main/java/com/collusic/collusicbe/domain/track/Track.java
+++ b/server/collusic-be/src/main/java/com/collusic/collusicbe/domain/track/Track.java
@@ -4,6 +4,7 @@ import com.collusic.collusicbe.domain.BaseTimeEntity;
 import com.collusic.collusicbe.domain.member.Member;
 import com.collusic.collusicbe.domain.project.Project;
 import lombok.AccessLevel;
+import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
@@ -45,4 +46,18 @@ public class Track extends BaseTimeEntity {
 
     @Column(columnDefinition = "integer default 50", nullable = false)
     private int volume;
+
+    @Column(nullable = false)
+    private int order;
+
+    @Builder
+    public Track(String trackName, TrackTag trackTag, boolean editable, Member creator, Project project, Measure measure, int volume) {
+        this.trackName = trackName;
+        this.trackTag = trackTag;
+        this.editable = editable;
+        this.creator = creator;
+        this.project = project;
+        this.measure = measure;
+        this.volume = volume;
+    }
 }

--- a/server/collusic-be/src/main/java/com/collusic/collusicbe/domain/track/Track.java
+++ b/server/collusic-be/src/main/java/com/collusic/collusicbe/domain/track/Track.java
@@ -48,10 +48,10 @@ public class Track extends BaseTimeEntity {
     private int volume;
 
     @Column(nullable = false)
-    private int order;
+    private int orderInProject;
 
     @Builder
-    public Track(String trackName, TrackTag trackTag, boolean editable, Member creator, Project project, Measure measure, int volume, int order) {
+    public Track(String trackName, TrackTag trackTag, boolean editable, Member creator, Project project, Measure measure, int volume, int orderInProject) {
         this.trackName = trackName;
         this.trackTag = trackTag;
         this.editable = editable;
@@ -59,6 +59,7 @@ public class Track extends BaseTimeEntity {
         this.project = project;
         this.measure = measure;
         this.volume = volume;
-        this.order = order;
+        this.orderInProject = orderInProject;
+        this.fileUrl = "empty"; // TODO : 음원 파일 데이터 시 추가 처리할 것
     }
 }

--- a/server/collusic-be/src/main/java/com/collusic/collusicbe/domain/track/Track.java
+++ b/server/collusic-be/src/main/java/com/collusic/collusicbe/domain/track/Track.java
@@ -51,7 +51,7 @@ public class Track extends BaseTimeEntity {
     private int order;
 
     @Builder
-    public Track(String trackName, TrackTag trackTag, boolean editable, Member creator, Project project, Measure measure, int volume) {
+    public Track(String trackName, TrackTag trackTag, boolean editable, Member creator, Project project, Measure measure, int volume, int order) {
         this.trackName = trackName;
         this.trackTag = trackTag;
         this.editable = editable;
@@ -59,5 +59,6 @@ public class Track extends BaseTimeEntity {
         this.project = project;
         this.measure = measure;
         this.volume = volume;
+        this.order = order;
     }
 }

--- a/server/collusic-be/src/main/java/com/collusic/collusicbe/domain/track/Track.java
+++ b/server/collusic-be/src/main/java/com/collusic/collusicbe/domain/track/Track.java
@@ -3,7 +3,6 @@ package com.collusic.collusicbe.domain.track;
 import com.collusic.collusicbe.domain.BaseTimeEntity;
 import com.collusic.collusicbe.domain.member.Member;
 import com.collusic.collusicbe.domain.project.Project;
-import com.collusic.collusicbe.domain.state.State;
 import lombok.AccessLevel;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
@@ -44,6 +43,6 @@ public class Track extends BaseTimeEntity {
     @Column(nullable = false)
     private String fileUrl;
 
-    @Enumerated(EnumType.STRING)
-    private State trackState;
+    @Column(columnDefinition = "integer default 50", nullable = false)
+    private int volume;
 }

--- a/server/collusic-be/src/main/java/com/collusic/collusicbe/domain/track/TrackRepository.java
+++ b/server/collusic-be/src/main/java/com/collusic/collusicbe/domain/track/TrackRepository.java
@@ -1,0 +1,6 @@
+package com.collusic.collusicbe.domain.track;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface TrackRepository extends JpaRepository<Track, Long> {
+}

--- a/server/collusic-be/src/main/java/com/collusic/collusicbe/domain/track/TrackTag.java
+++ b/server/collusic-be/src/main/java/com/collusic/collusicbe/domain/track/TrackTag.java
@@ -1,12 +1,13 @@
 package com.collusic.collusicbe.domain.track;
 
-import com.fasterxml.jackson.annotation.JsonCreator;
-import com.fasterxml.jackson.annotation.JsonFormat;
-import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.annotation.JsonValue;
 import lombok.Getter;
 import lombok.RequiredArgsConstructor;
 
-@JsonFormat(shape = JsonFormat.Shape.OBJECT)
+import java.util.Map;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
+
 @Getter
 @RequiredArgsConstructor
 public enum TrackTag {
@@ -21,10 +22,13 @@ public enum TrackTag {
     MARACAS("마라카스"),
     ETC("etc");
 
-    private final String name;
+    private static final Map<String, TrackTag> stringToEnum =
+            Stream.of(values()).collect(Collectors.toMap(x -> x.label, x -> x));
 
-    @JsonCreator
-    public static TrackTag fromJson(@JsonProperty("key") String name) {
-        return valueOf(name);
+    @JsonValue
+    private final String label;
+
+    public static TrackTag valueOfLabel(String label) {
+        return stringToEnum.get(label);
     }
 }

--- a/server/collusic-be/src/main/java/com/collusic/collusicbe/domain/track/TrackTag.java
+++ b/server/collusic-be/src/main/java/com/collusic/collusicbe/domain/track/TrackTag.java
@@ -1,5 +1,30 @@
 package com.collusic.collusicbe.domain.track;
 
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonFormat;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+@JsonFormat(shape = JsonFormat.Shape.OBJECT)
+@Getter
+@RequiredArgsConstructor
 public enum TrackTag {
-    // TODO : 태그 추가해야함.
+    PIANO("피아노"),
+    DRUM("드럼"),
+    VOCAL("보컬"),
+    CLAP("박수"),
+    ACOUSTIC_GUITAR("어쿠스틱 기타"),
+    ELECTRIC_GUITAR("일렉 기타"),
+    VIOLIN("바이올린"),
+    RECORDER("리코더"),
+    MARACAS("마라카스"),
+    ETC("etc");
+
+    private final String name;
+
+    @JsonCreator
+    public static TrackTag fromJson(@JsonProperty("key") String name) {
+        return valueOf(name);
+    }
 }

--- a/server/collusic-be/src/main/java/com/collusic/collusicbe/global/exception/ForbiddenException.java
+++ b/server/collusic-be/src/main/java/com/collusic/collusicbe/global/exception/ForbiddenException.java
@@ -1,0 +1,10 @@
+package com.collusic.collusicbe.global.exception;
+
+import lombok.NoArgsConstructor;
+
+@NoArgsConstructor
+public class ForbiddenException extends RuntimeException {
+    public ForbiddenException(String message) {
+        super(message);
+    }
+}

--- a/server/collusic-be/src/main/java/com/collusic/collusicbe/global/exception/UnAuthorizedException.java
+++ b/server/collusic-be/src/main/java/com/collusic/collusicbe/global/exception/UnAuthorizedException.java
@@ -1,0 +1,10 @@
+package com.collusic.collusicbe.global.exception;
+
+import lombok.NoArgsConstructor;
+
+@NoArgsConstructor
+public class UnAuthorizedException extends RuntimeException {
+    public UnAuthorizedException(String message) {
+        super(message);
+    }
+}

--- a/server/collusic-be/src/main/java/com/collusic/collusicbe/global/exception/advice/ExceptionControllerAdvice.java
+++ b/server/collusic-be/src/main/java/com/collusic/collusicbe/global/exception/advice/ExceptionControllerAdvice.java
@@ -10,6 +10,8 @@ import org.springframework.web.bind.annotation.ResponseStatus;
 import org.springframework.web.bind.annotation.RestControllerAdvice;
 import org.springframework.web.method.annotation.MethodArgumentTypeMismatchException;
 
+import javax.validation.ConstraintViolationException;
+
 @RestControllerAdvice
 public class ExceptionControllerAdvice {
 
@@ -28,5 +30,17 @@ public class ExceptionControllerAdvice {
     @ExceptionHandler(DuplicatedNicknameException.class)
     public ExceptionInfoResponse duplicatedNicknameExceptionHandler(DuplicatedNicknameException e) {
         return new ExceptionInfoResponse(HttpStatus.BAD_REQUEST.getReasonPhrase(), e.getMessage());
+    }
+
+    @ResponseStatus(HttpStatus.BAD_REQUEST)
+    @ExceptionHandler(ConstraintViolationException.class)
+    public Object constraintViolationExceptionHandler(Exception e) {
+        return e.getMessage();
+    }
+
+    @ResponseStatus(HttpStatus.BAD_REQUEST)
+    @ExceptionHandler({IllegalArgumentException.class, IllegalStateException.class})
+    public Object illegalExceptionHandler(Exception e) {
+        return e.getMessage();
     }
 }

--- a/server/collusic-be/src/main/java/com/collusic/collusicbe/global/exception/advice/ExceptionControllerAdvice.java
+++ b/server/collusic-be/src/main/java/com/collusic/collusicbe/global/exception/advice/ExceptionControllerAdvice.java
@@ -3,6 +3,7 @@ package com.collusic.collusicbe.global.exception.advice;
 import com.collusic.collusicbe.global.exception.DuplicatedNicknameException;
 import com.collusic.collusicbe.global.exception.ExceptionInfoResponse;
 import com.collusic.collusicbe.global.exception.ExceptionResponse;
+import com.collusic.collusicbe.global.exception.UnAuthorizedException;
 import org.springframework.http.HttpStatus;
 import org.springframework.validation.BindException;
 import org.springframework.web.bind.annotation.ExceptionHandler;
@@ -30,6 +31,12 @@ public class ExceptionControllerAdvice {
     @ExceptionHandler(DuplicatedNicknameException.class)
     public ExceptionInfoResponse duplicatedNicknameExceptionHandler(DuplicatedNicknameException e) {
         return new ExceptionInfoResponse(HttpStatus.BAD_REQUEST.getReasonPhrase(), e.getMessage());
+    }
+
+    @ResponseStatus(HttpStatus.UNAUTHORIZED)
+    @ExceptionHandler(UnAuthorizedException.class)
+    public ExceptionInfoResponse unAuthorizedExceptionHandler(UnAuthorizedException e) {
+        return new ExceptionInfoResponse(HttpStatus.UNAUTHORIZED.getReasonPhrase(), e.getMessage());
     }
 
     @ResponseStatus(HttpStatus.BAD_REQUEST)

--- a/server/collusic-be/src/main/java/com/collusic/collusicbe/global/exception/advice/ExceptionControllerAdvice.java
+++ b/server/collusic-be/src/main/java/com/collusic/collusicbe/global/exception/advice/ExceptionControllerAdvice.java
@@ -1,9 +1,6 @@
 package com.collusic.collusicbe.global.exception.advice;
 
-import com.collusic.collusicbe.global.exception.DuplicatedNicknameException;
-import com.collusic.collusicbe.global.exception.ExceptionInfoResponse;
-import com.collusic.collusicbe.global.exception.ExceptionResponse;
-import com.collusic.collusicbe.global.exception.UnAuthorizedException;
+import com.collusic.collusicbe.global.exception.*;
 import org.springframework.http.HttpStatus;
 import org.springframework.validation.BindException;
 import org.springframework.web.bind.annotation.ExceptionHandler;
@@ -12,6 +9,7 @@ import org.springframework.web.bind.annotation.RestControllerAdvice;
 import org.springframework.web.method.annotation.MethodArgumentTypeMismatchException;
 
 import javax.validation.ConstraintViolationException;
+import java.util.NoSuchElementException;
 
 @RestControllerAdvice
 public class ExceptionControllerAdvice {
@@ -48,6 +46,18 @@ public class ExceptionControllerAdvice {
     @ResponseStatus(HttpStatus.BAD_REQUEST)
     @ExceptionHandler({IllegalArgumentException.class, IllegalStateException.class})
     public Object illegalExceptionHandler(Exception e) {
+        return e.getMessage();
+    }
+
+    @ResponseStatus(HttpStatus.NOT_FOUND)
+    @ExceptionHandler(NoSuchElementException.class)
+    public Object noSuchElementExceptionHandler(Exception e) {
+        return e.getMessage();
+    }
+
+    @ResponseStatus(HttpStatus.FORBIDDEN)
+    @ExceptionHandler(ForbiddenException.class)
+    public Object forbiddenExceptionHandler(Exception e) {
         return e.getMessage();
     }
 }

--- a/server/collusic-be/src/main/java/com/collusic/collusicbe/service/ProjectService.java
+++ b/server/collusic-be/src/main/java/com/collusic/collusicbe/service/ProjectService.java
@@ -5,6 +5,8 @@ import com.collusic.collusicbe.domain.project.ProjectRepository;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 
+import java.util.NoSuchElementException;
+
 @Service
 @RequiredArgsConstructor
 public class ProjectService {
@@ -12,6 +14,6 @@ public class ProjectService {
     private final ProjectRepository projectRepository;
 
     public Project findById(Long id) {
-        return projectRepository.findById(id).orElseThrow();
+        return projectRepository.findById(id).orElseThrow(NoSuchElementException::new);
     }
 }

--- a/server/collusic-be/src/main/java/com/collusic/collusicbe/service/ProjectService.java
+++ b/server/collusic-be/src/main/java/com/collusic/collusicbe/service/ProjectService.java
@@ -1,0 +1,17 @@
+package com.collusic.collusicbe.service;
+
+import com.collusic.collusicbe.domain.project.Project;
+import com.collusic.collusicbe.domain.project.ProjectRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+@Service
+@RequiredArgsConstructor
+public class ProjectService {
+
+    private final ProjectRepository projectRepository;
+
+    public Project findById(Long id) {
+        return projectRepository.findById(id).orElseThrow();
+    }
+}

--- a/server/collusic-be/src/main/java/com/collusic/collusicbe/service/TrackService.java
+++ b/server/collusic-be/src/main/java/com/collusic/collusicbe/service/TrackService.java
@@ -39,7 +39,7 @@ public class TrackService {
         Track track = trackRepository.findById(trackId)
                                      .orElseThrow(NoSuchElementException::new);
 
-        if (!member.isSameMember(track.getCreator().getNickname())) {
+        if (!member.isSameMember(track.getCreator())) {
             throw new IllegalArgumentException();
         }
 
@@ -56,16 +56,16 @@ public class TrackService {
     public void delete(Member member, Project project, long id) {
         Track track = project.getTrack(id);
 
-        if (!member.isSameMember(track.getCreator().getNickname())) {
+        if (!member.isSameMember(track.getCreator())) {
             throw new IllegalStateException();
         }
 
-        if (track.getOrderInProject() == 0) {
+        if (project.getTracks().size() == 1) {
             projectRepository.delete(project);
             return;
         }
 
-        project.removeTrack(track.getOrderInProject());
+        project.removeTrack(track.getId());
         trackRepository.delete(track);
     }
 }

--- a/server/collusic-be/src/main/java/com/collusic/collusicbe/service/TrackService.java
+++ b/server/collusic-be/src/main/java/com/collusic/collusicbe/service/TrackService.java
@@ -2,6 +2,7 @@ package com.collusic.collusicbe.service;
 
 import com.collusic.collusicbe.domain.member.Member;
 import com.collusic.collusicbe.domain.project.Project;
+import com.collusic.collusicbe.domain.project.ProjectRepository;
 import com.collusic.collusicbe.domain.track.Track;
 import com.collusic.collusicbe.domain.track.TrackRepository;
 import com.collusic.collusicbe.web.controller.dto.TrackCreateRequestDto;
@@ -15,6 +16,7 @@ import java.util.NoSuchElementException;
 @RequiredArgsConstructor
 public class TrackService {
 
+    private final ProjectRepository projectRepository;
     private final TrackRepository trackRepository;
 
     public Track create(Member member, Project project, TrackCreateRequestDto trackData) {
@@ -49,5 +51,21 @@ public class TrackService {
                 trackData.getVolume());
 
         return trackRepository.save(track);
+    }
+
+    public void delete(Member member, Project project, long id) {
+        Track track = project.getTrack(id);
+
+        if (!member.isSameMember(track.getCreator().getNickname())) {
+            throw new IllegalStateException();
+        }
+
+        if (track.getOrderInProject() == 0) {
+            projectRepository.delete(project);
+            return;
+        }
+
+        project.removeTrack(track.getOrderInProject());
+        trackRepository.delete(track);
     }
 }

--- a/server/collusic-be/src/main/java/com/collusic/collusicbe/service/TrackService.java
+++ b/server/collusic-be/src/main/java/com/collusic/collusicbe/service/TrackService.java
@@ -16,7 +16,7 @@ public class TrackService {
 
     public Track create(Member member, Project project, TrackCreateRequestDto trackData) {
         if (project.isTrackFull()) {
-            throw new RuntimeException();
+            throw new IllegalStateException();
         }
         Track track = Track.builder()
                            .creator(member)
@@ -25,7 +25,7 @@ public class TrackService {
                            .trackTag(trackData.getTrackTag())
                            .measure(trackData.getMeasure())
                            .volume(trackData.getVolume())
-                           .order(project.getNextTrackOrder())
+                           .orderInProject(project.getNextTrackOrder())
                            .build();
         return trackRepository.save(track);
     }

--- a/server/collusic-be/src/main/java/com/collusic/collusicbe/service/TrackService.java
+++ b/server/collusic-be/src/main/java/com/collusic/collusicbe/service/TrackService.java
@@ -1,0 +1,20 @@
+package com.collusic.collusicbe.service;
+
+import com.collusic.collusicbe.domain.member.Member;
+import com.collusic.collusicbe.domain.project.Project;
+import com.collusic.collusicbe.domain.track.Track;
+import com.collusic.collusicbe.domain.track.TrackRepository;
+import com.collusic.collusicbe.web.controller.dto.TrackCreateRequestDto;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+@Service
+@RequiredArgsConstructor
+public class TrackService {
+
+    private final TrackRepository trackRepository;
+
+    public Track create(Member member, Project project, TrackCreateRequestDto trackData) {
+        return null;
+    }
+}

--- a/server/collusic-be/src/main/java/com/collusic/collusicbe/service/TrackService.java
+++ b/server/collusic-be/src/main/java/com/collusic/collusicbe/service/TrackService.java
@@ -5,6 +5,7 @@ import com.collusic.collusicbe.domain.project.Project;
 import com.collusic.collusicbe.domain.project.ProjectRepository;
 import com.collusic.collusicbe.domain.track.Track;
 import com.collusic.collusicbe.domain.track.TrackRepository;
+import com.collusic.collusicbe.global.exception.ForbiddenException;
 import com.collusic.collusicbe.web.controller.dto.TrackCreateRequestDto;
 import com.collusic.collusicbe.web.controller.dto.TrackUpdateRequestDto;
 import lombok.RequiredArgsConstructor;
@@ -57,7 +58,7 @@ public class TrackService {
         Track track = project.getTrack(id);
 
         if (!member.isSameMember(track.getCreator())) {
-            throw new IllegalStateException();
+            throw new ForbiddenException();
         }
 
         if (project.getTracks().size() == 1) {

--- a/server/collusic-be/src/main/java/com/collusic/collusicbe/service/TrackService.java
+++ b/server/collusic-be/src/main/java/com/collusic/collusicbe/service/TrackService.java
@@ -5,8 +5,11 @@ import com.collusic.collusicbe.domain.project.Project;
 import com.collusic.collusicbe.domain.track.Track;
 import com.collusic.collusicbe.domain.track.TrackRepository;
 import com.collusic.collusicbe.web.controller.dto.TrackCreateRequestDto;
+import com.collusic.collusicbe.web.controller.dto.TrackUpdateRequestDto;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
+
+import java.util.NoSuchElementException;
 
 @Service
 @RequiredArgsConstructor
@@ -27,6 +30,24 @@ public class TrackService {
                            .volume(trackData.getVolume())
                            .orderInProject(project.getNextTrackOrder())
                            .build();
+        return trackRepository.save(track);
+    }
+
+    public Track update(Member member, long trackId, TrackUpdateRequestDto trackData) {
+        Track track = trackRepository.findById(trackId)
+                                     .orElseThrow(NoSuchElementException::new);
+
+        if (!member.isSameMember(track.getCreator().getNickname())) {
+            throw new IllegalArgumentException();
+        }
+
+        track.changeTrackInfo(
+                trackData.getTrackName(),
+                trackData.getTrackTag(),
+                trackData.getEditable(),
+                trackData.getMeasure(),
+                trackData.getVolume());
+
         return trackRepository.save(track);
     }
 }

--- a/server/collusic-be/src/main/java/com/collusic/collusicbe/service/TrackService.java
+++ b/server/collusic-be/src/main/java/com/collusic/collusicbe/service/TrackService.java
@@ -15,6 +15,18 @@ public class TrackService {
     private final TrackRepository trackRepository;
 
     public Track create(Member member, Project project, TrackCreateRequestDto trackData) {
-        return null;
+        if (project.isTrackFull()) {
+            throw new RuntimeException();
+        }
+        Track track = Track.builder()
+                           .creator(member)
+                           .project(project)
+                           .trackName(trackData.getTrackName())
+                           .trackTag(trackData.getTrackTag())
+                           .measure(trackData.getMeasure())
+                           .volume(trackData.getVolume())
+                           .order(project.getNextTrackOrder())
+                           .build();
+        return trackRepository.save(track);
     }
 }

--- a/server/collusic-be/src/main/java/com/collusic/collusicbe/web/controller/ProjectController.java
+++ b/server/collusic-be/src/main/java/com/collusic/collusicbe/web/controller/ProjectController.java
@@ -1,0 +1,23 @@
+package com.collusic.collusicbe.web.controller;
+
+import com.collusic.collusicbe.domain.project.Project;
+import com.collusic.collusicbe.service.ProjectService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequiredArgsConstructor
+public class ProjectController {
+
+    private final ProjectService projectService;
+
+    @GetMapping("/projects/{projectId}")
+    public ResponseEntity<Void> readProject(@PathVariable Long projectId) {
+        Project project = projectService.findById(projectId);
+
+        return ResponseEntity.ok(null); // TODO: project resposne dto 클래스 추가하여 반영할 것
+    }
+}

--- a/server/collusic-be/src/main/java/com/collusic/collusicbe/web/controller/TrackController.java
+++ b/server/collusic-be/src/main/java/com/collusic/collusicbe/web/controller/TrackController.java
@@ -35,7 +35,7 @@ public class TrackController {
     public ResponseEntity<Void> updateTrack(@LoginMember Member member, @PathVariable Long trackId, @Validated @RequestBody final TrackUpdateRequestDto requestDto) {
         Project project = projectService.findById(requestDto.getProjectId());
 
-        if (!project.getLastTrack().getId().equals(trackId)) {
+        if (!project.isLastTrackId(trackId)) {
             throw new IllegalArgumentException();
         }
 

--- a/server/collusic-be/src/main/java/com/collusic/collusicbe/web/controller/TrackController.java
+++ b/server/collusic-be/src/main/java/com/collusic/collusicbe/web/controller/TrackController.java
@@ -33,8 +33,14 @@ public class TrackController {
 
     @PutMapping("/tracks/{trackId}")
     public ResponseEntity<Void> updateTrack(@LoginMember Member member, @PathVariable Long trackId, @Validated @RequestBody final TrackUpdateRequestDto requestDto) {
-        trackService.update(member, trackId, requestDto);
+        Project project = projectService.findById(requestDto.getProjectId());
+
+        if (!project.getLastTrack().getId().equals(trackId)) {
+            throw new IllegalArgumentException();
+        }
+
+        trackService.update(member,trackId,requestDto);
 
         return ResponseEntity.ok(null);
-    }
+}
 }

--- a/server/collusic-be/src/main/java/com/collusic/collusicbe/web/controller/TrackController.java
+++ b/server/collusic-be/src/main/java/com/collusic/collusicbe/web/controller/TrackController.java
@@ -8,13 +8,11 @@ import com.collusic.collusicbe.service.ProjectService;
 import com.collusic.collusicbe.service.TrackService;
 import com.collusic.collusicbe.web.controller.dto.TrackCreateRequestDto;
 import com.collusic.collusicbe.web.controller.dto.TrackCreateResponseDto;
+import com.collusic.collusicbe.web.controller.dto.TrackUpdateRequestDto;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
 import org.springframework.validation.annotation.Validated;
-import org.springframework.web.bind.annotation.PathVariable;
-import org.springframework.web.bind.annotation.PostMapping;
-import org.springframework.web.bind.annotation.RequestBody;
-import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.bind.annotation.*;
 
 import java.net.URI;
 
@@ -31,5 +29,12 @@ public class TrackController {
         Track track = trackService.create(member, project, requestDto);
 
         return ResponseEntity.created(URI.create("/projects/" + projectId + "/tracks/" + track.getId())).body(new TrackCreateResponseDto(track));
+    }
+
+    @PutMapping("/tracks/{trackId}")
+    public ResponseEntity<Void> updateTrack(@LoginMember Member member, @PathVariable Long trackId, @Validated @RequestBody final TrackUpdateRequestDto requestDto) {
+        trackService.update(member, trackId, requestDto);
+
+        return ResponseEntity.ok(null);
     }
 }

--- a/server/collusic-be/src/main/java/com/collusic/collusicbe/web/controller/TrackController.java
+++ b/server/collusic-be/src/main/java/com/collusic/collusicbe/web/controller/TrackController.java
@@ -43,4 +43,12 @@ public class TrackController {
 
         return ResponseEntity.ok(null);
 }
+
+    @DeleteMapping("/projects/{projectId}/tracks/{trackId}")
+    public ResponseEntity<Void> deleteTrack(@LoginMember Member member, @PathVariable Long projectId, @PathVariable Long trackId) {
+        Project project = projectService.findById(projectId);
+        trackService.delete(member, project, trackId);
+
+        return ResponseEntity.ok(null);
+    }
 }

--- a/server/collusic-be/src/main/java/com/collusic/collusicbe/web/controller/TrackController.java
+++ b/server/collusic-be/src/main/java/com/collusic/collusicbe/web/controller/TrackController.java
@@ -31,18 +31,18 @@ public class TrackController {
         return ResponseEntity.created(URI.create("/projects/" + projectId + "/tracks/" + track.getId())).body(new TrackCreateResponseDto(track));
     }
 
-    @PutMapping("/tracks/{trackId}")
-    public ResponseEntity<Void> updateTrack(@LoginMember Member member, @PathVariable Long trackId, @Validated @RequestBody final TrackUpdateRequestDto requestDto) {
-        Project project = projectService.findById(requestDto.getProjectId());
+    @PutMapping("/projects/{projectId}/tracks/{trackId}")
+    public ResponseEntity<Void> updateTrack(@LoginMember Member member, @PathVariable Long projectId, @PathVariable Long trackId, @Validated @RequestBody final TrackUpdateRequestDto requestDto) {
+        Project project = projectService.findById(projectId);
 
         if (!project.isLastTrackId(trackId)) {
             throw new IllegalArgumentException();
         }
 
-        trackService.update(member,trackId,requestDto);
+        trackService.update(member, trackId, requestDto);
 
         return ResponseEntity.ok(null);
-}
+    }
 
     @DeleteMapping("/projects/{projectId}/tracks/{trackId}")
     public ResponseEntity<Void> deleteTrack(@LoginMember Member member, @PathVariable Long projectId, @PathVariable Long trackId) {

--- a/server/collusic-be/src/main/java/com/collusic/collusicbe/web/controller/TrackController.java
+++ b/server/collusic-be/src/main/java/com/collusic/collusicbe/web/controller/TrackController.java
@@ -1,0 +1,35 @@
+package com.collusic.collusicbe.web.controller;
+
+import com.collusic.collusicbe.config.auth.LoginMember;
+import com.collusic.collusicbe.domain.member.Member;
+import com.collusic.collusicbe.domain.project.Project;
+import com.collusic.collusicbe.domain.track.Track;
+import com.collusic.collusicbe.service.ProjectService;
+import com.collusic.collusicbe.service.TrackService;
+import com.collusic.collusicbe.web.controller.dto.TrackCreateRequestDto;
+import com.collusic.collusicbe.web.controller.dto.TrackCreateResponseDto;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.validation.annotation.Validated;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RestController;
+
+import java.net.URI;
+
+@RestController
+@RequiredArgsConstructor
+public class TrackController {
+
+    private final TrackService trackService;
+    private final ProjectService projectService;
+
+    @PostMapping("/projects/{projectId}/tracks")
+    public ResponseEntity<TrackCreateResponseDto> createTrack(@LoginMember Member member, @PathVariable Long projectId, @Validated @RequestBody final TrackCreateRequestDto requestDto) {
+        Project project = projectService.findById(projectId);
+        Track track = trackService.create(member, project, requestDto);
+
+        return ResponseEntity.created(URI.create("/projects/" + projectId + "/tracks/" + track.getId())).body(new TrackCreateResponseDto(track));
+    }
+}

--- a/server/collusic-be/src/main/java/com/collusic/collusicbe/web/controller/dto/ProjectResponseDto.java
+++ b/server/collusic-be/src/main/java/com/collusic/collusicbe/web/controller/dto/ProjectResponseDto.java
@@ -1,0 +1,4 @@
+package com.collusic.collusicbe.web.controller.dto;
+
+public class ProjectResponseDto {
+}

--- a/server/collusic-be/src/main/java/com/collusic/collusicbe/web/controller/dto/TrackCreateRequestDto.java
+++ b/server/collusic-be/src/main/java/com/collusic/collusicbe/web/controller/dto/TrackCreateRequestDto.java
@@ -7,23 +7,33 @@ import lombok.Getter;
 import lombok.NoArgsConstructor;
 import lombok.Setter;
 
+import javax.validation.constraints.*;
+
 @Getter
 @Setter
 @NoArgsConstructor
 public class TrackCreateRequestDto {
 
+    @NotBlank
+    @Size(min = 1, max = 20, message = "트랙 명은 1자 이상 20자 이내로 한다.")
     private String trackName;
+    @NotNull
     private TrackTag trackTag;
-    private boolean editable;
+    @NotNull
+    private Boolean editable;
+    @NotNull
     private Measure measure;
-    private int volume;
+    @NotNull
+    @Min(0)
+    @Max(100)
+    private Integer volume;
 
     @Builder
-    public TrackCreateRequestDto(String trackName, TrackTag trackTag, boolean editable, Measure measure, int volume) {
+    public TrackCreateRequestDto(String trackName, String trackTag, Boolean editable, Integer measure, Integer volume) {
         this.trackName = trackName;
-        this.trackTag = trackTag;
+        this.trackTag = TrackTag.valueOfLabel(trackTag);
         this.editable = editable;
-        this.measure = measure;
+        this.measure = Measure.valueOfInteger(measure);
         this.volume = volume;
     }
 }

--- a/server/collusic-be/src/main/java/com/collusic/collusicbe/web/controller/dto/TrackCreateRequestDto.java
+++ b/server/collusic-be/src/main/java/com/collusic/collusicbe/web/controller/dto/TrackCreateRequestDto.java
@@ -1,0 +1,29 @@
+package com.collusic.collusicbe.web.controller.dto;
+
+import com.collusic.collusicbe.domain.track.Measure;
+import com.collusic.collusicbe.domain.track.TrackTag;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+@Getter
+@Setter
+@NoArgsConstructor
+public class TrackCreateRequestDto {
+
+    private String trackName;
+    private TrackTag trackTag;
+    private boolean editable;
+    private Measure measure;
+    private int volume;
+
+    @Builder
+    public TrackCreateRequestDto(String trackName, TrackTag trackTag, boolean editable, Measure measure, int volume) {
+        this.trackName = trackName;
+        this.trackTag = trackTag;
+        this.editable = editable;
+        this.measure = measure;
+        this.volume = volume;
+    }
+}

--- a/server/collusic-be/src/main/java/com/collusic/collusicbe/web/controller/dto/TrackCreateResponseDto.java
+++ b/server/collusic-be/src/main/java/com/collusic/collusicbe/web/controller/dto/TrackCreateResponseDto.java
@@ -1,0 +1,16 @@
+package com.collusic.collusicbe.web.controller.dto;
+
+import com.collusic.collusicbe.domain.track.Track;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@NoArgsConstructor
+@Getter
+public class TrackCreateResponseDto {
+
+    private Long id;
+
+    public TrackCreateResponseDto(Track track) {
+        this.id = track.getId();
+    }
+}

--- a/server/collusic-be/src/main/java/com/collusic/collusicbe/web/controller/dto/TrackUpdateRequestDto.java
+++ b/server/collusic-be/src/main/java/com/collusic/collusicbe/web/controller/dto/TrackUpdateRequestDto.java
@@ -14,6 +14,8 @@ import javax.validation.constraints.*;
 @NoArgsConstructor
 public class TrackUpdateRequestDto {
 
+    @NotNull
+    private Long projectId;
     @NotBlank
     @Size(min = 1, max = 20, message = "트랙 명은 1자 이상 20자 이내로 한다.")
     private String trackName;
@@ -29,7 +31,8 @@ public class TrackUpdateRequestDto {
     private Integer volume;
 
     @Builder
-    public TrackUpdateRequestDto(String trackName, String trackTag, Boolean editable, Integer measure, Integer volume) {
+    public TrackUpdateRequestDto(Long projectId, String trackName, String trackTag, Boolean editable, Integer measure, Integer volume) {
+        this.projectId = projectId;
         this.trackName = trackName;
         this.trackTag = TrackTag.valueOfLabel(trackTag);
         this.editable = editable;

--- a/server/collusic-be/src/main/java/com/collusic/collusicbe/web/controller/dto/TrackUpdateRequestDto.java
+++ b/server/collusic-be/src/main/java/com/collusic/collusicbe/web/controller/dto/TrackUpdateRequestDto.java
@@ -14,8 +14,6 @@ import javax.validation.constraints.*;
 @NoArgsConstructor
 public class TrackUpdateRequestDto {
 
-    @NotNull
-    private Long projectId;
     @NotBlank
     @Size(min = 1, max = 20, message = "트랙 명은 1자 이상 20자 이내로 한다.")
     private String trackName;
@@ -31,8 +29,7 @@ public class TrackUpdateRequestDto {
     private Integer volume;
 
     @Builder
-    public TrackUpdateRequestDto(Long projectId, String trackName, String trackTag, Boolean editable, Integer measure, Integer volume) {
-        this.projectId = projectId;
+    public TrackUpdateRequestDto(String trackName, String trackTag, Boolean editable, Integer measure, Integer volume) {
         this.trackName = trackName;
         this.trackTag = TrackTag.valueOfLabel(trackTag);
         this.editable = editable;

--- a/server/collusic-be/src/main/java/com/collusic/collusicbe/web/controller/dto/TrackUpdateRequestDto.java
+++ b/server/collusic-be/src/main/java/com/collusic/collusicbe/web/controller/dto/TrackUpdateRequestDto.java
@@ -1,0 +1,39 @@
+package com.collusic.collusicbe.web.controller.dto;
+
+import com.collusic.collusicbe.domain.track.Measure;
+import com.collusic.collusicbe.domain.track.TrackTag;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+import javax.validation.constraints.*;
+
+@Getter
+@Setter
+@NoArgsConstructor
+public class TrackUpdateRequestDto {
+
+    @NotBlank
+    @Size(min = 1, max = 20, message = "트랙 명은 1자 이상 20자 이내로 한다.")
+    private String trackName;
+    @NotNull
+    private TrackTag trackTag;
+    @NotNull
+    private Boolean editable;
+    @NotNull
+    private Measure measure;
+    @NotNull
+    @Min(0)
+    @Max(100)
+    private Integer volume;
+
+    @Builder
+    public TrackUpdateRequestDto(String trackName, String trackTag, Boolean editable, Integer measure, Integer volume) {
+        this.trackName = trackName;
+        this.trackTag = TrackTag.valueOfLabel(trackTag);
+        this.editable = editable;
+        this.measure = Measure.valueOfInteger(measure);
+        this.volume = volume;
+    }
+}

--- a/server/collusic-be/src/main/resources/application.yml
+++ b/server/collusic-be/src/main/resources/application.yml
@@ -21,6 +21,7 @@ spring:
           batch_size: 10
     hibernate:
       ddl-auto: create
+    generate-ddl: true
 
   h2:
     console:

--- a/server/collusic-be/src/main/resources/import.sql
+++ b/server/collusic-be/src/main/resources/import.sql
@@ -1,3 +1,15 @@
 insert into member (member_id, auth_id, email, nickname, role, sns_type) values (1, 'test_auth_id', 'test@collusic.com', 'test_user1', 'USER', 'KAKAO');
 
 insert into project (project_id, project_name, bpm, file_url) values (1, 'test project', 50, 'test_url');
+insert into project (project_id, project_name, bpm, file_url) values (2, 'test project', 50, 'test_url');
+
+insert into track (track_id, member_id, editable, file_url, measure, order_in_project, project_id, track_name, track_tag, volume) values (1, 1, true, 'test', 'FOUR', 0, 2, 'test1', 'PIANO', 50);
+insert into track (track_id, member_id, editable, file_url, measure, order_in_project, project_id, track_name, track_tag, volume) values (2, 1, true, 'test', 'FOUR', 1, 2, 'test1', 'PIANO', 50);
+insert into track (track_id, member_id, editable, file_url, measure, order_in_project, project_id, track_name, track_tag, volume) values (3, 1, true, 'test', 'FOUR', 2, 2, 'test1', 'PIANO', 50);
+insert into track (track_id, member_id, editable, file_url, measure, order_in_project, project_id, track_name, track_tag, volume) values (4, 1, true, 'test', 'FOUR', 3, 2, 'test1', 'PIANO', 50);
+insert into track (track_id, member_id, editable, file_url, measure, order_in_project, project_id, track_name, track_tag, volume) values (5, 1, true, 'test', 'FOUR', 4, 2, 'test1', 'PIANO', 50);
+insert into track (track_id, member_id, editable, file_url, measure, order_in_project, project_id, track_name, track_tag, volume) values (6, 1, true, 'test', 'FOUR', 5, 2, 'test1', 'PIANO', 50);
+insert into track (track_id, member_id, editable, file_url, measure, order_in_project, project_id, track_name, track_tag, volume) values (7, 1, true, 'test', 'FOUR', 6, 2, 'test1', 'PIANO', 50);
+insert into track (track_id, member_id, editable, file_url, measure, order_in_project, project_id, track_name, track_tag, volume) values (8, 1, true, 'test', 'FOUR', 7, 2, 'test1', 'PIANO', 50);
+insert into track (track_id, member_id, editable, file_url, measure, order_in_project, project_id, track_name, track_tag, volume) values (9, 1, true, 'test', 'FOUR', 8, 2, 'test1', 'PIANO', 50);
+insert into track (track_id, member_id, editable, file_url, measure, order_in_project, project_id, track_name, track_tag, volume) values (10, 1, true, 'test', 'FOUR', 9, 2, 'test1', 'PIANO', 50);

--- a/server/collusic-be/src/main/resources/import.sql
+++ b/server/collusic-be/src/main/resources/import.sql
@@ -1,0 +1,1 @@
+insert into member (member_id, auth_id, email, nickname, role, sns_type) values (1, 'test_auth_id', 'test@collusic.com', 'test_user1', 'ROLE_USER', 'KAKAO');

--- a/server/collusic-be/src/main/resources/import.sql
+++ b/server/collusic-be/src/main/resources/import.sql
@@ -3,6 +3,8 @@ insert into member (member_id, auth_id, email, nickname, role, sns_type) values 
 insert into project (project_id, project_name, bpm, file_url) values (1, 'test project', 50, 'test_url');
 insert into project (project_id, project_name, bpm, file_url) values (2, 'test project', 50, 'test_url');
 insert into project (project_id, project_name, bpm, file_url) values (3, 'test project', 50, 'test_url');
+insert into project (project_id, project_name, bpm, file_url) values (4, 'test project', 50, 'test_url');
+insert into project (project_id, project_name, bpm, file_url) values (5, 'test project', 50, 'test_url');
 
 insert into track (track_id, member_id, editable, file_url, measure, order_in_project, project_id, track_name, track_tag, volume) values (1, 1, true, 'test', 'FOUR', 0, 2, 'test1', 'PIANO', 50);
 insert into track (track_id, member_id, editable, file_url, measure, order_in_project, project_id, track_name, track_tag, volume) values (2, 1, true, 'test', 'FOUR', 1, 2, 'test1', 'PIANO', 50);
@@ -17,3 +19,7 @@ insert into track (track_id, member_id, editable, file_url, measure, order_in_pr
 
 insert into track (track_id, member_id, editable, file_url, measure, order_in_project, project_id, track_name, track_tag, volume) values (11, 1, true, 'test', 'FOUR', 0, 3, 'test1', 'PIANO', 50);
 insert into track (track_id, member_id, editable, file_url, measure, order_in_project, project_id, track_name, track_tag, volume) values (12, 1, true, 'test', 'FOUR', 1, 3, 'test1', 'PIANO', 50);
+
+insert into track (track_id, member_id, editable, file_url, measure, order_in_project, project_id, track_name, track_tag, volume) values (13, 1, true, 'test', 'FOUR', 0, 4, 'test1', 'PIANO', 50);
+insert into track (track_id, member_id, editable, file_url, measure, order_in_project, project_id, track_name, track_tag, volume) values (14, 2, true, 'test', 'FOUR', 1, 4, 'test1', 'PIANO', 50);
+insert into track (track_id, member_id, editable, file_url, measure, order_in_project, project_id, track_name, track_tag, volume) values (15, 1, true, 'test', 'FOUR', 0, 5, 'test1', 'PIANO', 50);

--- a/server/collusic-be/src/main/resources/import.sql
+++ b/server/collusic-be/src/main/resources/import.sql
@@ -1,1 +1,3 @@
-insert into member (member_id, auth_id, email, nickname, role, sns_type) values (1, 'test_auth_id', 'test@collusic.com', 'test_user1', 'ROLE_USER', 'KAKAO');
+insert into member (member_id, auth_id, email, nickname, role, sns_type) values (1, 'test_auth_id', 'test@collusic.com', 'test_user1', 'USER', 'KAKAO');
+
+insert into project (project_id, project_name, bpm, file_url) values (1, 'test project', 50, 'test_url');

--- a/server/collusic-be/src/main/resources/import.sql
+++ b/server/collusic-be/src/main/resources/import.sql
@@ -2,6 +2,7 @@ insert into member (member_id, auth_id, email, nickname, role, sns_type) values 
 
 insert into project (project_id, project_name, bpm, file_url) values (1, 'test project', 50, 'test_url');
 insert into project (project_id, project_name, bpm, file_url) values (2, 'test project', 50, 'test_url');
+insert into project (project_id, project_name, bpm, file_url) values (3, 'test project', 50, 'test_url');
 
 insert into track (track_id, member_id, editable, file_url, measure, order_in_project, project_id, track_name, track_tag, volume) values (1, 1, true, 'test', 'FOUR', 0, 2, 'test1', 'PIANO', 50);
 insert into track (track_id, member_id, editable, file_url, measure, order_in_project, project_id, track_name, track_tag, volume) values (2, 1, true, 'test', 'FOUR', 1, 2, 'test1', 'PIANO', 50);
@@ -13,3 +14,6 @@ insert into track (track_id, member_id, editable, file_url, measure, order_in_pr
 insert into track (track_id, member_id, editable, file_url, measure, order_in_project, project_id, track_name, track_tag, volume) values (8, 1, true, 'test', 'FOUR', 7, 2, 'test1', 'PIANO', 50);
 insert into track (track_id, member_id, editable, file_url, measure, order_in_project, project_id, track_name, track_tag, volume) values (9, 1, true, 'test', 'FOUR', 8, 2, 'test1', 'PIANO', 50);
 insert into track (track_id, member_id, editable, file_url, measure, order_in_project, project_id, track_name, track_tag, volume) values (10, 1, true, 'test', 'FOUR', 9, 2, 'test1', 'PIANO', 50);
+
+insert into track (track_id, member_id, editable, file_url, measure, order_in_project, project_id, track_name, track_tag, volume) values (11, 1, true, 'test', 'FOUR', 0, 3, 'test1', 'PIANO', 50);
+insert into track (track_id, member_id, editable, file_url, measure, order_in_project, project_id, track_name, track_tag, volume) values (12, 1, true, 'test', 'FOUR', 1, 3, 'test1', 'PIANO', 50);

--- a/server/collusic-be/src/main/resources/import.sql
+++ b/server/collusic-be/src/main/resources/import.sql
@@ -1,4 +1,5 @@
 insert into member (member_id, auth_id, email, nickname, role, sns_type) values (1, 'test_auth_id', 'test@collusic.com', 'test_user1', 'USER', 'KAKAO');
+insert into member (member_id, auth_id, email, nickname, role, sns_type) values (2, 'test_auth_id2', 'test2@collusic.com', 'test_user2', 'USER', 'KAKAO');
 
 insert into project (project_id, project_name, bpm, file_url) values (1, 'test project', 50, 'test_url');
 insert into project (project_id, project_name, bpm, file_url) values (2, 'test project', 50, 'test_url');

--- a/server/collusic-be/src/test/java/com/collusic/collusicbe/acceptanceTest/AbstractAcceptanceTest.java
+++ b/server/collusic-be/src/test/java/com/collusic/collusicbe/acceptanceTest/AbstractAcceptanceTest.java
@@ -1,0 +1,51 @@
+package com.collusic.collusicbe.acceptanceTest;
+
+import com.collusic.collusicbe.domain.member.Member;
+import com.collusic.collusicbe.domain.member.MemberRepository;
+import com.collusic.collusicbe.util.JWTUtil;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.test.web.client.TestRestTemplate;
+import org.springframework.http.HttpEntity;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.MediaType;
+import org.springframework.test.context.ActiveProfiles;
+
+@ActiveProfiles("local")
+@SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT)
+public abstract class AbstractAcceptanceTest {
+
+    @Autowired
+    private TestRestTemplate restTemplate;
+
+    @Autowired
+    private MemberRepository memberRepository;
+
+    protected TestRestTemplate template() {
+        return restTemplate;
+    }
+
+    protected Member testMember() {
+        return memberRepository.findById(1L).get();
+    }
+
+    protected String testToken() {
+        Member member = testMember();
+        return JWTUtil.createAccessToken(member.getEmail(), member.getRole().getKey());
+    }
+
+    protected HttpEntity<Object> requestEntityWithToken(Object data) {
+        HttpHeaders headers = new HttpHeaders();
+        headers.setBearerAuth(testToken());
+        headers.setContentType(MediaType.APPLICATION_JSON);
+
+        return new HttpEntity<>(data, headers);
+    }
+
+    protected HttpEntity<Object> requestEntity(Object data) {
+        HttpHeaders headers = new HttpHeaders();
+        headers.setContentType(MediaType.APPLICATION_JSON);
+
+        return new HttpEntity<>(data, headers);
+    }
+}

--- a/server/collusic-be/src/test/java/com/collusic/collusicbe/acceptanceTest/TrackAcceptanceTest.java
+++ b/server/collusic-be/src/test/java/com/collusic/collusicbe/acceptanceTest/TrackAcceptanceTest.java
@@ -1,12 +1,14 @@
 package com.collusic.collusicbe.acceptanceTest;
 
 import com.collusic.collusicbe.domain.track.TrackRepository;
+import com.collusic.collusicbe.web.controller.dto.ProjectResponseDto;
 import com.collusic.collusicbe.web.controller.dto.TrackCreateRequestDto;
 import com.collusic.collusicbe.web.controller.dto.TrackCreateResponseDto;
 import com.collusic.collusicbe.web.controller.dto.TrackUpdateRequestDto;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.http.HttpEntity;
 import org.springframework.http.HttpMethod;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
@@ -146,18 +148,24 @@ public class TrackAcceptanceTest extends AbstractAcceptanceTest {
     @Test
     @DisplayName("트랙 삭제 테스트 - 정상적인 요청의 경우 OK(200)으로 응답")
     void testDeletingTrack() {
-        // TODO
+        ResponseEntity<Void> response = template().exchange("/tracks/13", HttpMethod.DELETE, requestEntityWithToken(null), Void.class);
+        assertThat(response.getStatusCode()).isEqualTo(HttpStatus.OK);
     }
 
     @Test
     @DisplayName("트랙 삭제 테스트 - 정상적인 요청의 경우 OK(200)으로 응답 + 프로젝트의 루트 트랙인 경우 프로젝트도 삭제되어야 함")
     void testDeletingTrack2() {
-        // TODO
+        ResponseEntity<Void> responseForDeleting = template().exchange("/tracks/15", HttpMethod.DELETE, requestEntityWithToken(null), Void.class);
+        assertThat(responseForDeleting.getStatusCode()).isEqualTo(HttpStatus.OK);
+
+        ResponseEntity<ProjectResponseDto> responseForCheckingDeleted = template().getForEntity("/projects/4", ProjectResponseDto.class);
+        assertThat(responseForCheckingDeleted.getStatusCode()).isEqualTo(HttpStatus.NOT_FOUND);
     }
 
     @Test
     @DisplayName("트랙 삭제 테스트 - 현재 사용자가 등록하지 않은 트랙을 삭제 요청하는 경우 FORBIDDEN(403)으로 응답")
     void testBadRequestDeletingTrack() {
-        // TODO
+        ResponseEntity<Void> response = template().exchange("/tracks/14", HttpMethod.DELETE, requestEntityWithToken(null), Void.class);
+        assertThat(response.getStatusCode()).isEqualTo(HttpStatus.FORBIDDEN);
     }
 }

--- a/server/collusic-be/src/test/java/com/collusic/collusicbe/acceptanceTest/TrackAcceptanceTest.java
+++ b/server/collusic-be/src/test/java/com/collusic/collusicbe/acceptanceTest/TrackAcceptanceTest.java
@@ -1,8 +1,8 @@
 package com.collusic.collusicbe.acceptanceTest;
 
 import com.collusic.collusicbe.domain.track.TrackRepository;
-import com.collusic.collusicbe.domain.track.TrackTag;
 import com.collusic.collusicbe.web.controller.dto.TrackCreateRequestDto;
+import com.collusic.collusicbe.web.controller.dto.TrackCreateResponseDto;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -23,13 +23,13 @@ public class TrackAcceptanceTest extends AbstractAcceptanceTest {
         // given
         TrackCreateRequestDto requestDto = TrackCreateRequestDto.builder()
                                                                 .trackName("test track name")
-                                                                .trackTag(TrackTag.valueOf("PIANO"))
+                                                                .trackTag("피아노")
                                                                 .editable(true)
                                                                 .volume(50)
                                                                 .build();
 
         // when
-        ResponseEntity<Long> response = template().postForEntity("/projects/1/tracks", requestEntityWithToken(requestDto), Long.class);
+        ResponseEntity<TrackCreateResponseDto> response = template().postForEntity("/projects/1/tracks", requestEntityWithToken(requestDto), TrackCreateResponseDto.class);
 
         // then
         assertThat(response.getStatusCode()).isEqualTo(HttpStatus.CREATED);
@@ -41,13 +41,13 @@ public class TrackAcceptanceTest extends AbstractAcceptanceTest {
         // given
         TrackCreateRequestDto requestDto = TrackCreateRequestDto.builder()
                                                                 .trackName("test track name")
-                                                                .trackTag(TrackTag.valueOf("PIANO"))
+                                                                .trackTag("피아노")
                                                                 .editable(true)
                                                                 .volume(50)
                                                                 .build();
 
         // when
-        ResponseEntity<Long> response = template().postForEntity("/projects/1/tracks", requestEntity(requestDto), Long.class);
+        ResponseEntity<TrackCreateResponseDto> response = template().postForEntity("/projects/1/tracks", requestEntity(requestDto), TrackCreateResponseDto.class);
 
         // then
         assertThat(response.getStatusCode()).isEqualTo(HttpStatus.UNAUTHORIZED);
@@ -57,27 +57,28 @@ public class TrackAcceptanceTest extends AbstractAcceptanceTest {
     @DisplayName("트랙 생성 테스트 - 필수 데이터가 누락된 요청인 경우 BAD_REQUEST(400)으로 응답")
     void testBadRequestCreatingTrack() {
         // given
-        TrackCreateRequestDto emptyDto = new TrackCreateRequestDto();
+        TrackCreateRequestDto emptyDto = TrackCreateRequestDto.builder()
+                                                              .build();
 
         // when
-        ResponseEntity<Long> response = template().postForEntity("/projects/1/tracks", requestEntityWithToken(emptyDto), Long.class);
+        ResponseEntity<TrackCreateResponseDto> response = template().postForEntity("/projects/1/tracks", requestEntityWithToken(emptyDto), TrackCreateResponseDto.class);
 
         // then
         assertThat(response.getStatusCode()).isEqualTo(HttpStatus.BAD_REQUEST);
     }
 
     @Test
-    @DisplayName("트랙 생성 테스트 - 프로젝트에 더이상 트랙을 등록할 수 없을 때의 요청의 경우 FORBIDDEN(403)으로 응답")
+    @DisplayName("트랙 생성 테스트 - 프로젝트에 더이상 트랙을 등록할 수 없을 때의 요청의 경우 BAD_REQUEST(400)으로 응답")
     void testForbiddenCreatingTrack() {
         // given
         TrackCreateRequestDto requestDto = TrackCreateRequestDto.builder()
                                                                 .trackName("test track name")
-                                                                .trackTag(TrackTag.valueOf("PIANO"))
+                                                                .trackTag("피아노")
                                                                 .editable(true)
                                                                 .volume(50)
                                                                 .build();
         // when
-        ResponseEntity<Long> response = template().postForEntity("/projects/1/tracks", requestEntityWithToken(requestDto), Long.class);
+        ResponseEntity<TrackCreateResponseDto> response = template().postForEntity("/projects/1/tracks", requestEntityWithToken(requestDto), TrackCreateResponseDto.class);
 
         // then
         assertThat(response.getStatusCode()).isEqualTo(HttpStatus.CREATED);

--- a/server/collusic-be/src/test/java/com/collusic/collusicbe/acceptanceTest/TrackAcceptanceTest.java
+++ b/server/collusic-be/src/test/java/com/collusic/collusicbe/acceptanceTest/TrackAcceptanceTest.java
@@ -95,7 +95,6 @@ public class TrackAcceptanceTest extends AbstractAcceptanceTest {
     void testUpdatingTrack() {
         // given
         TrackUpdateRequestDto requestDto = TrackUpdateRequestDto.builder()
-                                                                .projectId(3L)
                                                                 .trackName("test track name")
                                                                 .trackTag("피아노")
                                                                 .editable(true)
@@ -104,7 +103,7 @@ public class TrackAcceptanceTest extends AbstractAcceptanceTest {
                                                                 .build();
 
         // when
-        ResponseEntity<Void> response = template().exchange("/tracks/12", HttpMethod.PUT, requestEntityWithToken(requestDto), Void.class);
+        ResponseEntity<Void> response = template().exchange("/projects/3/tracks/12", HttpMethod.PUT, requestEntityWithToken(requestDto), Void.class);
 
         // then
         assertThat(response.getStatusCode()).isEqualTo(HttpStatus.OK);
@@ -118,7 +117,7 @@ public class TrackAcceptanceTest extends AbstractAcceptanceTest {
                                                                 .build();
 
         // when
-        ResponseEntity<Void> response = template().exchange("/tracks/12", HttpMethod.PUT, requestEntityWithToken(requestDto), Void.class);
+        ResponseEntity<Void> response = template().exchange("/projects/3/tracks/12", HttpMethod.PUT, requestEntityWithToken(requestDto), Void.class);
 
         // then
         assertThat(response.getStatusCode()).isEqualTo(HttpStatus.BAD_REQUEST);
@@ -129,7 +128,6 @@ public class TrackAcceptanceTest extends AbstractAcceptanceTest {
     void testBadRequestUpdatingTrack_when_not_last_track_in_project() {
         // given
         TrackUpdateRequestDto requestDto = TrackUpdateRequestDto.builder()
-                                                                .projectId(3L)
                                                                 .trackName("test track name")
                                                                 .trackTag("피아노")
                                                                 .editable(true)
@@ -138,7 +136,7 @@ public class TrackAcceptanceTest extends AbstractAcceptanceTest {
                                                                 .build();
 
         // when
-        ResponseEntity<Void> response = template().exchange("/tracks/11", HttpMethod.PUT, requestEntityWithToken(requestDto), Void.class);
+        ResponseEntity<Void> response = template().exchange("/projects/3/tracks/11", HttpMethod.PUT, requestEntityWithToken(requestDto), Void.class);
 
         // then
         assertThat(response.getStatusCode()).isEqualTo(HttpStatus.BAD_REQUEST);

--- a/server/collusic-be/src/test/java/com/collusic/collusicbe/acceptanceTest/TrackAcceptanceTest.java
+++ b/server/collusic-be/src/test/java/com/collusic/collusicbe/acceptanceTest/TrackAcceptanceTest.java
@@ -8,7 +8,6 @@ import com.collusic.collusicbe.web.controller.dto.TrackUpdateRequestDto;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.http.HttpEntity;
 import org.springframework.http.HttpMethod;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
@@ -148,24 +147,24 @@ public class TrackAcceptanceTest extends AbstractAcceptanceTest {
     @Test
     @DisplayName("트랙 삭제 테스트 - 정상적인 요청의 경우 OK(200)으로 응답")
     void testDeletingTrack() {
-        ResponseEntity<Void> response = template().exchange("/tracks/13", HttpMethod.DELETE, requestEntityWithToken(null), Void.class);
+        ResponseEntity<Void> response = template().exchange("/projects/4/tracks/13", HttpMethod.DELETE, requestEntityWithToken(null), Void.class);
         assertThat(response.getStatusCode()).isEqualTo(HttpStatus.OK);
     }
 
     @Test
     @DisplayName("트랙 삭제 테스트 - 정상적인 요청의 경우 OK(200)으로 응답 + 프로젝트의 루트 트랙인 경우 프로젝트도 삭제되어야 함")
     void testDeletingTrack2() {
-        ResponseEntity<Void> responseForDeleting = template().exchange("/tracks/15", HttpMethod.DELETE, requestEntityWithToken(null), Void.class);
+        ResponseEntity<Void> responseForDeleting = template().exchange("/projects/5/tracks/15", HttpMethod.DELETE, requestEntityWithToken(null), Void.class);
         assertThat(responseForDeleting.getStatusCode()).isEqualTo(HttpStatus.OK);
 
-        ResponseEntity<ProjectResponseDto> responseForCheckingDeleted = template().getForEntity("/projects/4", ProjectResponseDto.class);
+        ResponseEntity<ProjectResponseDto> responseForCheckingDeleted = template().getForEntity("/projects/5", ProjectResponseDto.class);
         assertThat(responseForCheckingDeleted.getStatusCode()).isEqualTo(HttpStatus.NOT_FOUND);
     }
 
     @Test
     @DisplayName("트랙 삭제 테스트 - 현재 사용자가 등록하지 않은 트랙을 삭제 요청하는 경우 FORBIDDEN(403)으로 응답")
     void testBadRequestDeletingTrack() {
-        ResponseEntity<Void> response = template().exchange("/tracks/14", HttpMethod.DELETE, requestEntityWithToken(null), Void.class);
+        ResponseEntity<Void> response = template().exchange("/projects/4/tracks/14", HttpMethod.DELETE, requestEntityWithToken(null), Void.class);
         assertThat(response.getStatusCode()).isEqualTo(HttpStatus.FORBIDDEN);
     }
 }

--- a/server/collusic-be/src/test/java/com/collusic/collusicbe/acceptanceTest/TrackAcceptanceTest.java
+++ b/server/collusic-be/src/test/java/com/collusic/collusicbe/acceptanceTest/TrackAcceptanceTest.java
@@ -94,6 +94,7 @@ public class TrackAcceptanceTest extends AbstractAcceptanceTest {
     void testUpdatingTrack() {
         // given
         TrackUpdateRequestDto requestDto = TrackUpdateRequestDto.builder()
+                                                                .projectId(3L)
                                                                 .trackName("test track name")
                                                                 .trackTag("피아노")
                                                                 .editable(true)
@@ -102,7 +103,7 @@ public class TrackAcceptanceTest extends AbstractAcceptanceTest {
                                                                 .build();
 
         // when
-        ResponseEntity<Void> response = template().exchange("/tracks/1", HttpMethod.PUT, requestEntityWithToken(requestDto), Void.class);
+        ResponseEntity<Void> response = template().exchange("/tracks/12", HttpMethod.PUT, requestEntityWithToken(requestDto), Void.class);
 
         // then
         assertThat(response.getStatusCode()).isEqualTo(HttpStatus.OK);
@@ -116,7 +117,27 @@ public class TrackAcceptanceTest extends AbstractAcceptanceTest {
                                                                 .build();
 
         // when
-        ResponseEntity<Void> response = template().exchange("/tracks/1", HttpMethod.PUT, requestEntityWithToken(requestDto), Void.class);
+        ResponseEntity<Void> response = template().exchange("/tracks/12", HttpMethod.PUT, requestEntityWithToken(requestDto), Void.class);
+
+        // then
+        assertThat(response.getStatusCode()).isEqualTo(HttpStatus.BAD_REQUEST);
+    }
+
+    @Test
+    @DisplayName("트랙 수정 테스트 - 해당 트랙이 속한 프로젝트의 마지막 프로젝트가 아닌 경우 BAD_REQUEST(400)으로 응답")
+    void testBadRequestUpdatingTrack_when_not_last_track_in_project() {
+        // given
+        TrackUpdateRequestDto requestDto = TrackUpdateRequestDto.builder()
+                                                                .projectId(3L)
+                                                                .trackName("test track name")
+                                                                .trackTag("피아노")
+                                                                .editable(true)
+                                                                .measure(4)
+                                                                .volume(50)
+                                                                .build();
+
+        // when
+        ResponseEntity<Void> response = template().exchange("/tracks/11", HttpMethod.PUT, requestEntityWithToken(requestDto), Void.class);
 
         // then
         assertThat(response.getStatusCode()).isEqualTo(HttpStatus.BAD_REQUEST);

--- a/server/collusic-be/src/test/java/com/collusic/collusicbe/acceptanceTest/TrackAcceptanceTest.java
+++ b/server/collusic-be/src/test/java/com/collusic/collusicbe/acceptanceTest/TrackAcceptanceTest.java
@@ -3,9 +3,11 @@ package com.collusic.collusicbe.acceptanceTest;
 import com.collusic.collusicbe.domain.track.TrackRepository;
 import com.collusic.collusicbe.web.controller.dto.TrackCreateRequestDto;
 import com.collusic.collusicbe.web.controller.dto.TrackCreateResponseDto;
+import com.collusic.collusicbe.web.controller.dto.TrackUpdateRequestDto;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.http.HttpMethod;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 
@@ -90,21 +92,35 @@ public class TrackAcceptanceTest extends AbstractAcceptanceTest {
     @Test
     @DisplayName("트랙 수정 테스트 - 정상적인 요청의 경우 OK(200)으로 응답")
     void testUpdatingTrack() {
-        // TODO
+        // given
+        TrackUpdateRequestDto requestDto = TrackUpdateRequestDto.builder()
+                                                                .trackName("test track name")
+                                                                .trackTag("피아노")
+                                                                .editable(true)
+                                                                .measure(4)
+                                                                .volume(50)
+                                                                .build();
+
+        // when
+        ResponseEntity<Void> response = template().exchange("/tracks/1", HttpMethod.PUT, requestEntityWithToken(requestDto), Void.class);
+
+        // then
+        assertThat(response.getStatusCode()).isEqualTo(HttpStatus.OK);
     }
 
     @Test
     @DisplayName("트랙 수정 테스트 - 비정상적인 요청의 경우 BAD_REQUEST(400)으로 응답")
     void testBadRequestUpdatingTrack() {
-        // TODO
-    }
+        // given
+        TrackUpdateRequestDto requestDto = TrackUpdateRequestDto.builder()
+                                                                .build();
 
-    @Test
-    @DisplayName("트랙 수정 테스트 - 잠금이 활성화되어 있는 트랙을 수정 요청하는 경우 UNAUTHORIZED(401)으로 응답")
-    void testBadRequestUpdatingTrack2() {
-        // TODO
-    }
+        // when
+        ResponseEntity<Void> response = template().exchange("/tracks/1", HttpMethod.PUT, requestEntityWithToken(requestDto), Void.class);
 
+        // then
+        assertThat(response.getStatusCode()).isEqualTo(HttpStatus.BAD_REQUEST);
+    }
 
     @Test
     @DisplayName("트랙 삭제 테스트 - 정상적인 요청의 경우 OK(200)으로 응답")
@@ -119,7 +135,7 @@ public class TrackAcceptanceTest extends AbstractAcceptanceTest {
     }
 
     @Test
-    @DisplayName("트랙 삭제 테스트 - 현재 사용자가 등록하지 않은 트랙을 삭제 요청하는 경우 UNAUTHORIZED(401)으로 응답")
+    @DisplayName("트랙 삭제 테스트 - 현재 사용자가 등록하지 않은 트랙을 삭제 요청하는 경우 FORBIDDEN(403)으로 응답")
     void testBadRequestDeletingTrack() {
         // TODO
     }

--- a/server/collusic-be/src/test/java/com/collusic/collusicbe/acceptanceTest/TrackAcceptanceTest.java
+++ b/server/collusic-be/src/test/java/com/collusic/collusicbe/acceptanceTest/TrackAcceptanceTest.java
@@ -1,0 +1,122 @@
+package com.collusic.collusicbe.acceptanceTest;
+
+import com.collusic.collusicbe.domain.track.TrackRepository;
+import com.collusic.collusicbe.domain.track.TrackTag;
+import com.collusic.collusicbe.web.controller.dto.TrackCreateRequestDto;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+@DisplayName("Track Acceptance Test")
+public class TrackAcceptanceTest extends AbstractAcceptanceTest {
+
+    @Autowired
+    private TrackRepository trackRepository;
+
+    @Test
+    @DisplayName("트랙 생성 테스트 - 정상적인 요청의 경우 CREATED(201)으로 응답")
+    void testCreatingTrack() {
+        // given
+        TrackCreateRequestDto requestDto = TrackCreateRequestDto.builder()
+                                                                .trackName("test track name")
+                                                                .trackTag(TrackTag.valueOf("PIANO"))
+                                                                .editable(true)
+                                                                .volume(50)
+                                                                .build();
+
+        // when
+        ResponseEntity<Long> response = template().postForEntity("/projects/1/tracks", requestEntityWithToken(requestDto), Long.class);
+
+        // then
+        assertThat(response.getStatusCode()).isEqualTo(HttpStatus.CREATED);
+    }
+
+    @Test
+    @DisplayName("트랙 생성 테스트 - 로그인하지 않은 사용자의 요청인 경우 UNAUTHORIZED(401)으로 응답")
+    void testUnauthorizedCreatingTrack() {
+        // given
+        TrackCreateRequestDto requestDto = TrackCreateRequestDto.builder()
+                                                                .trackName("test track name")
+                                                                .trackTag(TrackTag.valueOf("PIANO"))
+                                                                .editable(true)
+                                                                .volume(50)
+                                                                .build();
+
+        // when
+        ResponseEntity<Long> response = template().postForEntity("/projects/1/tracks", requestEntity(requestDto), Long.class);
+
+        // then
+        assertThat(response.getStatusCode()).isEqualTo(HttpStatus.UNAUTHORIZED);
+    }
+
+    @Test
+    @DisplayName("트랙 생성 테스트 - 필수 데이터가 누락된 요청인 경우 BAD_REQUEST(400)으로 응답")
+    void testBadRequestCreatingTrack() {
+        // given
+        TrackCreateRequestDto emptyDto = new TrackCreateRequestDto();
+
+        // when
+        ResponseEntity<Long> response = template().postForEntity("/projects/1/tracks", requestEntityWithToken(emptyDto), Long.class);
+
+        // then
+        assertThat(response.getStatusCode()).isEqualTo(HttpStatus.BAD_REQUEST);
+    }
+
+    @Test
+    @DisplayName("트랙 생성 테스트 - 프로젝트에 더이상 트랙을 등록할 수 없을 때의 요청의 경우 FORBIDDEN(403)으로 응답")
+    void testForbiddenCreatingTrack() {
+        // given
+        TrackCreateRequestDto requestDto = TrackCreateRequestDto.builder()
+                                                                .trackName("test track name")
+                                                                .trackTag(TrackTag.valueOf("PIANO"))
+                                                                .editable(true)
+                                                                .volume(50)
+                                                                .build();
+        // when
+        ResponseEntity<Long> response = template().postForEntity("/projects/1/tracks", requestEntityWithToken(requestDto), Long.class);
+
+        // then
+        assertThat(response.getStatusCode()).isEqualTo(HttpStatus.CREATED);
+    }
+
+    @Test
+    @DisplayName("트랙 수정 테스트 - 정상적인 요청의 경우 OK(200)으로 응답")
+    void testUpdatingTrack() {
+        // TODO
+    }
+
+    @Test
+    @DisplayName("트랙 수정 테스트 - 비정상적인 요청의 경우 BAD_REQUEST(400)으로 응답")
+    void testBadRequestUpdatingTrack() {
+        // TODO
+    }
+
+    @Test
+    @DisplayName("트랙 수정 테스트 - 잠금이 활성화되어 있는 트랙을 수정 요청하는 경우 UNAUTHORIZED(401)으로 응답")
+    void testBadRequestUpdatingTrack2() {
+        // TODO
+    }
+
+
+    @Test
+    @DisplayName("트랙 삭제 테스트 - 정상적인 요청의 경우 OK(200)으로 응답")
+    void testDeletingTrack() {
+        // TODO
+    }
+
+    @Test
+    @DisplayName("트랙 삭제 테스트 - 정상적인 요청의 경우 OK(200)으로 응답 + 프로젝트의 루트 트랙인 경우 프로젝트도 삭제되어야 함")
+    void testDeletingTrack2() {
+        // TODO
+    }
+
+    @Test
+    @DisplayName("트랙 삭제 테스트 - 현재 사용자가 등록하지 않은 트랙을 삭제 요청하는 경우 UNAUTHORIZED(401)으로 응답")
+    void testBadRequestDeletingTrack() {
+        // TODO
+    }
+}

--- a/server/collusic-be/src/test/java/com/collusic/collusicbe/acceptanceTest/TrackAcceptanceTest.java
+++ b/server/collusic-be/src/test/java/com/collusic/collusicbe/acceptanceTest/TrackAcceptanceTest.java
@@ -25,6 +25,7 @@ public class TrackAcceptanceTest extends AbstractAcceptanceTest {
                                                                 .trackName("test track name")
                                                                 .trackTag("피아노")
                                                                 .editable(true)
+                                                                .measure(4)
                                                                 .volume(50)
                                                                 .build();
 
@@ -43,6 +44,7 @@ public class TrackAcceptanceTest extends AbstractAcceptanceTest {
                                                                 .trackName("test track name")
                                                                 .trackTag("피아노")
                                                                 .editable(true)
+                                                                .measure(4)
                                                                 .volume(50)
                                                                 .build();
 
@@ -74,14 +76,15 @@ public class TrackAcceptanceTest extends AbstractAcceptanceTest {
         TrackCreateRequestDto requestDto = TrackCreateRequestDto.builder()
                                                                 .trackName("test track name")
                                                                 .trackTag("피아노")
+                                                                .measure(4)
                                                                 .editable(true)
                                                                 .volume(50)
                                                                 .build();
         // when
-        ResponseEntity<TrackCreateResponseDto> response = template().postForEntity("/projects/1/tracks", requestEntityWithToken(requestDto), TrackCreateResponseDto.class);
+        ResponseEntity<TrackCreateResponseDto> response = template().postForEntity("/projects/2/tracks", requestEntityWithToken(requestDto), TrackCreateResponseDto.class);
 
         // then
-        assertThat(response.getStatusCode()).isEqualTo(HttpStatus.CREATED);
+        assertThat(response.getStatusCode()).isEqualTo(HttpStatus.BAD_REQUEST);
     }
 
     @Test

--- a/server/collusic-be/src/test/java/com/collusic/collusicbe/domain/track/TrackServiceTest.java
+++ b/server/collusic-be/src/test/java/com/collusic/collusicbe/domain/track/TrackServiceTest.java
@@ -4,12 +4,14 @@ import com.collusic.collusicbe.domain.member.Member;
 import com.collusic.collusicbe.domain.project.Project;
 import com.collusic.collusicbe.service.TrackService;
 import com.collusic.collusicbe.web.controller.dto.TrackCreateRequestDto;
+import com.collusic.collusicbe.web.controller.dto.TrackUpdateRequestDto;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Optional;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.jupiter.api.Assertions.assertThrows;
@@ -95,5 +97,85 @@ public class TrackServiceTest {
 
         // then
         assertThrows(IllegalStateException.class, () -> trackService.create(testMember, projectWithFullTrack, requestDto));
+    }
+
+    @Test
+    @DisplayName("트랙 수정 테스트 - 정상적인 수정")
+    void testUpdateTrack() {
+        // given
+        TrackUpdateRequestDto requestDto = TrackUpdateRequestDto.builder()
+                                                                .trackName("updated test track name")
+                                                                .trackTag("드럼")
+                                                                .editable(false)
+                                                                .volume(90)
+                                                                .build();
+        Track originalTrack = Track.builder()
+                                   .creator(testMember)
+                                   .project(testProject)
+                                   .trackName("test track name")
+                                   .trackTag(TrackTag.PIANO)
+                                   .editable(true)
+                                   .volume(50)
+                                   .build();
+
+        Track updatedTrack = Track.builder()
+                                  .creator(testMember)
+                                  .project(testProject)
+                                  .trackName("updated test track name")
+                                  .trackTag(TrackTag.DRUM)
+                                  .editable(false)
+                                  .volume(90)
+                                  .build();
+
+        // when
+        when(trackRepository.findById(any(Long.class))).thenReturn(Optional.of(originalTrack));
+        when(trackRepository.save(any(Track.class))).thenReturn(updatedTrack);
+        Track savedTrack = trackService.update(testMember, 1l, requestDto);
+
+        //then
+        assertThat(savedTrack.getTrackName()).isEqualTo(requestDto.getTrackName());
+        assertThat(savedTrack.getTrackTag()).isEqualTo(requestDto.getTrackTag());
+        assertThat(savedTrack.isEditable()).isEqualTo(requestDto.getEditable());
+        assertThat(savedTrack.getVolume()).isEqualTo(requestDto.getVolume());
+    }
+
+    @Test
+    @DisplayName("트랙 수정 테스트 - 트랙 생성자가 아닌 사용자의 요청의 경우 실패")
+    void testUpdateTrack_when_other_try_update_than_throw_exception() {
+        // given
+        TrackUpdateRequestDto requestDto = TrackUpdateRequestDto.builder()
+                                                                .trackName("updated test track name")
+                                                                .trackTag("드럼")
+                                                                .editable(false)
+                                                                .volume(90)
+                                                                .build();
+        Track originalTrack = Track.builder()
+                                   .creator(testMember)
+                                   .project(testProject)
+                                   .trackName("test track name")
+                                   .trackTag(TrackTag.PIANO)
+                                   .editable(true)
+                                   .volume(50)
+                                   .build();
+
+        Track updatedTrack = Track.builder()
+                                  .creator(testMember)
+                                  .project(testProject)
+                                  .trackName("updated test track name")
+                                  .trackTag(TrackTag.DRUM)
+                                  .editable(false)
+                                  .volume(90)
+                                  .build();
+
+        Member otherMember = Member.builder()
+                                   .nickname("otherMember")
+                                   .build();
+
+        // when
+        when(trackRepository.findById(any(Long.class))).thenReturn(Optional.of(originalTrack));
+        when(trackRepository.save(any(Track.class))).thenReturn(updatedTrack);
+
+        //then
+        assertThrows(IllegalArgumentException.class, () -> trackService.update(otherMember, 1l, requestDto));
     }
 }

--- a/server/collusic-be/src/test/java/com/collusic/collusicbe/domain/track/TrackServiceTest.java
+++ b/server/collusic-be/src/test/java/com/collusic/collusicbe/domain/track/TrackServiceTest.java
@@ -2,6 +2,7 @@ package com.collusic.collusicbe.domain.track;
 
 import com.collusic.collusicbe.domain.member.Member;
 import com.collusic.collusicbe.domain.project.Project;
+import com.collusic.collusicbe.domain.project.ProjectRepository;
 import com.collusic.collusicbe.service.TrackService;
 import com.collusic.collusicbe.web.controller.dto.TrackCreateRequestDto;
 import com.collusic.collusicbe.web.controller.dto.TrackUpdateRequestDto;
@@ -16,14 +17,14 @@ import java.util.Optional;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.mockito.ArgumentMatchers.any;
-import static org.mockito.Mockito.mock;
-import static org.mockito.Mockito.when;
+import static org.mockito.Mockito.*;
 
 @DisplayName("TestService Unit Test")
 public class TrackServiceTest {
 
     private TrackService trackService;
     private TrackRepository trackRepository;
+    private ProjectRepository projectRepository;
 
     private Member testMember;
     private Project testProject;
@@ -31,7 +32,8 @@ public class TrackServiceTest {
     @BeforeEach
     void setUp() {
         trackRepository = mock(TrackRepository.class);
-        trackService = new TrackService(trackRepository);
+        projectRepository = mock(ProjectRepository.class);
+        trackService = new TrackService(projectRepository, trackRepository);
 
         testMember = Member.builder()
                            .nickname("testMember")
@@ -177,5 +179,67 @@ public class TrackServiceTest {
 
         //then
         assertThrows(IllegalArgumentException.class, () -> trackService.update(otherMember, 1l, requestDto));
+    }
+
+    @Test
+    @DisplayName("트랙 삭제 테스트 - 정상적인 삭제")
+    void testDeleteTrack() {
+        List<Track> tempTracks = new ArrayList<>();
+        for (int i = 0; i < 5; i++) {
+            tempTracks.add(Track.builder()
+                                .id(i + 1L)
+                                .orderInProject(i)
+                                .creator(testMember)
+                                .build());
+        }
+
+        Project projectWithTracks = Project.builder()
+                                           .tracks(tempTracks)
+                                           .build();
+
+        Track track = Track.builder()
+                           .id(6L)
+                           .creator(testMember)
+                           .project(projectWithTracks)
+                           .trackName("test track name")
+                           .trackTag(TrackTag.PIANO)
+                           .editable(true)
+                           .orderInProject(5)
+                           .volume(50)
+                           .build();
+        tempTracks.add(track);
+
+        when(trackRepository.findById(any(Long.class))).thenReturn(Optional.of(track));
+        doNothing().when(trackRepository).delete(any(Track.class));
+
+        assertThat(projectWithTracks.getTracks().size()).isEqualTo(6);
+        trackService.delete(testMember, projectWithTracks, 6L);
+        verify(trackRepository, times(1)).delete(any(Track.class));
+        assertThat(projectWithTracks.getTracks().size()).isEqualTo(5);
+    }
+
+    @Test
+    @DisplayName("트랙 삭제 테스트 - 삭제하는 트랙이 본인이 생성한 트랙이 아닌 경우 실패")
+    void testDeleteTrack_when_not_track_creator_then_throw_exception() {
+        Track track = Track.builder()
+                           .id(1L)
+                           .creator(testMember)
+                           .project(testProject)
+                           .trackName("test track name")
+                           .trackTag(TrackTag.PIANO)
+                           .editable(true)
+                           .volume(50)
+                           .build();
+
+        testProject.addTrack(track);
+
+        Member anotherMember = Member.builder()
+                                     .nickname("anotherMember")
+                                     .build()
+
+        when(trackRepository.findById(any(Long.class))).thenReturn(Optional.of(track));
+        doThrow(IllegalStateException.class).when(trackRepository).delete(any(Track.class));
+
+        assertThrows(IllegalStateException.class, () -> trackService.delete(anotherMember, testProject, 1L));
     }
 }

--- a/server/collusic-be/src/test/java/com/collusic/collusicbe/domain/track/TrackServiceTest.java
+++ b/server/collusic-be/src/test/java/com/collusic/collusicbe/domain/track/TrackServiceTest.java
@@ -10,7 +10,6 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 
-import java.util.ArrayList;
 import java.util.List;
 import java.util.Optional;
 
@@ -28,6 +27,7 @@ public class TrackServiceTest {
 
     private Member testMember;
     private Project testProject;
+    private Track testTrack;
 
     @BeforeEach
     void setUp() {
@@ -35,67 +35,44 @@ public class TrackServiceTest {
         projectRepository = mock(ProjectRepository.class);
         trackService = new TrackService(projectRepository, trackRepository);
 
-        testMember = Member.builder()
-                           .nickname("testMember")
-                           .build();
+        testMember = Member.builder().id(1L).nickname("testMember").build();
 
-        testProject = Project.builder()
-                             .id(1L)
-                             .tracks(new ArrayList<>())
-                             .build();
+        testProject = Project.builder().id(1L).build();
+
+        testTrack = Track.builder().id(1L).creator(testMember).project(testProject).trackName("test track name").trackTag(TrackTag.PIANO).editable(true).volume(50).build();
     }
 
     @Test
     @DisplayName("트랙 생성 테스트 - 정상적인 생성")
     void testCreateTrack() {
         // given
-        TrackCreateRequestDto requestDto = TrackCreateRequestDto.builder()
-                                                                .trackName("test track name")
-                                                                .trackTag("피아노")
-                                                                .editable(true)
-                                                                .volume(50)
-                                                                .build();
-        Track track = Track.builder()
-                           .creator(testMember)
-                           .project(testProject)
-                           .trackName("test track name")
-                           .trackTag(TrackTag.PIANO)
-                           .editable(true)
-                           .volume(50)
-                           .build();
+        TrackCreateRequestDto requestDto = TrackCreateRequestDto.builder().trackName("test track name").trackTag("피아노").editable(true).volume(50).build();
 
         // when
-        when(trackRepository.save(any(Track.class))).thenReturn(track);
+        when(trackRepository.save(any(Track.class))).thenReturn(testTrack);
         Track savedTrack = trackService.create(testMember, testProject, requestDto);
 
         //then
         assertThat(savedTrack.getCreator().getNickname()).isEqualTo(testMember.getNickname());
         assertThat(savedTrack.getProject().getId()).isEqualTo(testProject.getId());
-        assertThat(savedTrack.getTrackName()).isEqualTo(track.getTrackName());
-        assertThat(savedTrack.getTrackTag()).isEqualTo(track.getTrackTag());
-        assertThat(savedTrack.isEditable()).isEqualTo(track.isEditable());
-        assertThat(savedTrack.getVolume()).isEqualTo(track.getVolume());
+        assertThat(savedTrack.getTrackName()).isEqualTo(testTrack.getTrackName());
+        assertThat(savedTrack.getTrackTag()).isEqualTo(testTrack.getTrackTag());
+        assertThat(savedTrack.isEditable()).isEqualTo(testTrack.isEditable());
+        assertThat(savedTrack.getVolume()).isEqualTo(testTrack.getVolume());
     }
 
     @Test
     @DisplayName("트랙 생성 테스트 - 프로젝트에 이미 10개의 트랙이 포함되어 있는 경우 생성 실패(throw IllegalStateException)")
     void testCreateTrack_when_already_over_size_then_throw_exception() {
         // given
-        TrackCreateRequestDto requestDto = TrackCreateRequestDto.builder()
-                                                                .trackName("test track name")
-                                                                .trackTag("피아노")
-                                                                .editable(true)
-                                                                .volume(50)
-                                                                .build();
+        TrackCreateRequestDto requestDto = TrackCreateRequestDto.builder().trackName("test track name").trackTag("피아노").editable(true).volume(50).build();
 
         // when
-        List<Track> tempTracks = new ArrayList<>();
+        Project projectWithFullTrack = Project.builder().build();
+
         for (int i = 0; i < 10; i++) {
-            tempTracks.add(Track.builder().build());
+            projectWithFullTrack.addTrack(Track.builder().build());
         }
-        Project projectWithFullTrack = Project.builder()
-                                              .tracks(tempTracks)
-                                              .build();
 
         // then
         assertThrows(IllegalStateException.class, () -> trackService.create(testMember, projectWithFullTrack, requestDto));
@@ -105,34 +82,15 @@ public class TrackServiceTest {
     @DisplayName("트랙 수정 테스트 - 정상적인 수정")
     void testUpdateTrack() {
         // given
-        TrackUpdateRequestDto requestDto = TrackUpdateRequestDto.builder()
-                                                                .trackName("updated test track name")
-                                                                .trackTag("드럼")
-                                                                .editable(false)
-                                                                .volume(90)
-                                                                .build();
-        Track originalTrack = Track.builder()
-                                   .creator(testMember)
-                                   .project(testProject)
-                                   .trackName("test track name")
-                                   .trackTag(TrackTag.PIANO)
-                                   .editable(true)
-                                   .volume(50)
-                                   .build();
+        TrackUpdateRequestDto requestDto = TrackUpdateRequestDto.builder().trackName("updated test track name").trackTag("드럼").editable(false).volume(90).build();
+        Track originalTrack = testTrack;
 
-        Track updatedTrack = Track.builder()
-                                  .creator(testMember)
-                                  .project(testProject)
-                                  .trackName("updated test track name")
-                                  .trackTag(TrackTag.DRUM)
-                                  .editable(false)
-                                  .volume(90)
-                                  .build();
+        Track updatedTrack = Track.builder().creator(testMember).project(testProject).trackName("updated test track name").trackTag(TrackTag.DRUM).editable(false).volume(90).build();
 
         // when
         when(trackRepository.findById(any(Long.class))).thenReturn(Optional.of(originalTrack));
         when(trackRepository.save(any(Track.class))).thenReturn(updatedTrack);
-        Track savedTrack = trackService.update(testMember, 1l, requestDto);
+        Track savedTrack = trackService.update(testMember, 1L, requestDto);
 
         //then
         assertThat(savedTrack.getTrackName()).isEqualTo(requestDto.getTrackName());
@@ -145,99 +103,56 @@ public class TrackServiceTest {
     @DisplayName("트랙 수정 테스트 - 트랙 생성자가 아닌 사용자의 요청의 경우 실패")
     void testUpdateTrack_when_other_try_update_than_throw_exception() {
         // given
-        TrackUpdateRequestDto requestDto = TrackUpdateRequestDto.builder()
-                                                                .trackName("updated test track name")
-                                                                .trackTag("드럼")
-                                                                .editable(false)
-                                                                .volume(90)
-                                                                .build();
-        Track originalTrack = Track.builder()
-                                   .creator(testMember)
-                                   .project(testProject)
-                                   .trackName("test track name")
-                                   .trackTag(TrackTag.PIANO)
-                                   .editable(true)
-                                   .volume(50)
-                                   .build();
+        TrackUpdateRequestDto requestDto = TrackUpdateRequestDto.builder().trackName("updated test track name").trackTag("드럼").editable(false).volume(90).build();
+        Track originalTrack = testTrack;
+        Track updatedTrack = Track.builder().creator(testMember).project(testProject).trackName("updated test track name").trackTag(TrackTag.DRUM).editable(false).volume(90).build();
 
-        Track updatedTrack = Track.builder()
-                                  .creator(testMember)
-                                  .project(testProject)
-                                  .trackName("updated test track name")
-                                  .trackTag(TrackTag.DRUM)
-                                  .editable(false)
-                                  .volume(90)
-                                  .build();
-
-        Member otherMember = Member.builder()
-                                   .nickname("otherMember")
-                                   .build();
+        Member anotherMember = Member.builder().id(2L).nickname("otherMember").build();
 
         // when
         when(trackRepository.findById(any(Long.class))).thenReturn(Optional.of(originalTrack));
         when(trackRepository.save(any(Track.class))).thenReturn(updatedTrack);
 
         //then
-        assertThrows(IllegalArgumentException.class, () -> trackService.update(otherMember, 1l, requestDto));
+        assertThrows(IllegalArgumentException.class, () -> trackService.update(anotherMember, 1l, requestDto));
     }
 
     @Test
     @DisplayName("트랙 삭제 테스트 - 정상적인 삭제")
     void testDeleteTrack() {
-        List<Track> tempTracks = new ArrayList<>();
-        for (int i = 0; i < 5; i++) {
-            tempTracks.add(Track.builder()
-                                .id(i + 1L)
-                                .orderInProject(i)
-                                .creator(testMember)
-                                .build());
+        Project projectWithTracks = Project.builder().build();
+
+        for (int i = 2; i <= 6; i++) {
+            projectWithTracks.addTrack(Track.builder().id((long) i).orderInProject(i - 1).creator(testMember).build());
         }
 
-        Project projectWithTracks = Project.builder()
-                                           .tracks(tempTracks)
-                                           .build();
+        projectWithTracks.addTrack(testTrack);
 
-        Track track = Track.builder()
-                           .id(6L)
-                           .creator(testMember)
-                           .project(projectWithTracks)
-                           .trackName("test track name")
-                           .trackTag(TrackTag.PIANO)
-                           .editable(true)
-                           .orderInProject(5)
-                           .volume(50)
-                           .build();
-        tempTracks.add(track);
-
-        when(trackRepository.findById(any(Long.class))).thenReturn(Optional.of(track));
+        when(trackRepository.findById(any(Long.class))).thenReturn(Optional.of(testTrack));
         doNothing().when(trackRepository).delete(any(Track.class));
 
-        assertThat(projectWithTracks.getTracks().size()).isEqualTo(6);
-        trackService.delete(testMember, projectWithTracks, 6L);
+        List<Track> tracksFromProject = projectWithTracks.getTracks();
+        assertThat(tracksFromProject.size()).isEqualTo(6);
+
+        trackService.delete(testMember, projectWithTracks, 1L);
+
         verify(trackRepository, times(1)).delete(any(Track.class));
-        assertThat(projectWithTracks.getTracks().size()).isEqualTo(5);
+        assertThat(tracksFromProject.size()).isEqualTo(5);
+        assertThat(tracksFromProject.stream().filter(t -> t.getId().equals(testTrack.getId())).count()).isEqualTo(0);
+
+        for (int i = 0; i < tracksFromProject.size(); i++) {
+            assertThat(tracksFromProject.get(i).getOrderInProject() == i).isTrue();
+        }
     }
 
     @Test
     @DisplayName("트랙 삭제 테스트 - 삭제하는 트랙이 본인이 생성한 트랙이 아닌 경우 실패")
     void testDeleteTrack_when_not_track_creator_then_throw_exception() {
-        Track track = Track.builder()
-                           .id(1L)
-                           .creator(testMember)
-                           .project(testProject)
-                           .trackName("test track name")
-                           .trackTag(TrackTag.PIANO)
-                           .editable(true)
-                           .volume(50)
-                           .build();
+        testProject.addTrack(testTrack);
 
-        testProject.addTrack(track);
+        Member anotherMember = Member.builder().id(2L).nickname("anotherMember").build();
 
-        Member anotherMember = Member.builder()
-                                     .nickname("anotherMember")
-                                     .build()
-
-        when(trackRepository.findById(any(Long.class))).thenReturn(Optional.of(track));
+        when(trackRepository.findById(any(Long.class))).thenReturn(Optional.of(testTrack));
         doThrow(IllegalStateException.class).when(trackRepository).delete(any(Track.class));
 
         assertThrows(IllegalStateException.class, () -> trackService.delete(anotherMember, testProject, 1L));

--- a/server/collusic-be/src/test/java/com/collusic/collusicbe/domain/track/TrackServiceTest.java
+++ b/server/collusic-be/src/test/java/com/collusic/collusicbe/domain/track/TrackServiceTest.java
@@ -47,7 +47,7 @@ public class TrackServiceTest {
         // given
         TrackCreateRequestDto requestDto = TrackCreateRequestDto.builder()
                                                                 .trackName("test track name")
-                                                                .trackTag(TrackTag.valueOf("PIANO"))
+                                                                .trackTag("피아노")
                                                                 .editable(true)
                                                                 .volume(50)
                                                                 .build();
@@ -74,12 +74,12 @@ public class TrackServiceTest {
     }
 
     @Test
-    @DisplayName("트랙 생성 테스트 - 프로젝트에 이미 10개의 트랙이 포함되어 있는 경우 생성 실패")
+    @DisplayName("트랙 생성 테스트 - 프로젝트에 이미 10개의 트랙이 포함되어 있는 경우 생성 실패(throw IllegalStateException)")
     void testCreateTrack_when_already_over_size_then_throw_exception() {
         // given
         TrackCreateRequestDto requestDto = TrackCreateRequestDto.builder()
                                                                 .trackName("test track name")
-                                                                .trackTag(TrackTag.valueOf("PIANO"))
+                                                                .trackTag("피아노")
                                                                 .editable(true)
                                                                 .volume(50)
                                                                 .build();
@@ -94,6 +94,6 @@ public class TrackServiceTest {
                                               .build();
 
         // then
-        assertThrows(RuntimeException.class, () -> trackService.create(testMember, projectWithFullTrack, requestDto));
+        assertThrows(IllegalStateException.class, () -> trackService.create(testMember, projectWithFullTrack, requestDto));
     }
 }

--- a/server/collusic-be/src/test/java/com/collusic/collusicbe/domain/track/TrackServiceTest.java
+++ b/server/collusic-be/src/test/java/com/collusic/collusicbe/domain/track/TrackServiceTest.java
@@ -1,0 +1,96 @@
+package com.collusic.collusicbe.domain.track;
+
+import com.collusic.collusicbe.domain.member.Member;
+import com.collusic.collusicbe.domain.project.Project;
+import com.collusic.collusicbe.service.TrackService;
+import com.collusic.collusicbe.web.controller.dto.TrackCreateRequestDto;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+@DisplayName("TestService Unit Test")
+public class TrackServiceTest {
+
+    private TrackService trackService;
+    private TrackRepository trackRepository;
+
+    private Member testMember;
+    private Project testProject;
+
+    @BeforeEach
+    void setUp() {
+        trackRepository = mock(TrackRepository.class);
+        trackService = new TrackService(trackRepository);
+
+        testMember = Member.builder()
+                           .nickname("testMember")
+                           .build();
+
+        testProject = Project.builder()
+                             .id(1L)
+                             .build();
+    }
+
+    @Test
+    @DisplayName("트랙 생성 테스트 - 정상적인 생성")
+    void testCreateTrack() {
+        // given
+        TrackCreateRequestDto requestDto = TrackCreateRequestDto.builder()
+                                                                .trackName("test track name")
+                                                                .trackTag(TrackTag.valueOf("PIANO"))
+                                                                .editable(true)
+                                                                .volume(50)
+                                                                .build();
+        Track track = Track.builder()
+                           .trackName("test track name")
+                           .trackTag(TrackTag.PIANO)
+                           .editable(true)
+                           .volume(50)
+                           .build();
+
+        // when
+        when(trackRepository.save(any(Track.class))).thenReturn(track);
+        Track savedTrack = trackService.create(testMember, testProject, requestDto);
+
+        //then
+        assertThat(savedTrack.getCreator().getNickname()).isEqualTo(testMember.getNickname());
+        assertThat(savedTrack.getProject().getId()).isEqualTo(testProject.getId());
+        assertThat(savedTrack.getTrackName()).isEqualTo(track.getTrackName());
+        assertThat(savedTrack.getTrackTag()).isEqualTo(track.getTrackTag());
+        assertThat(savedTrack.isEditable()).isEqualTo(track.isEditable());
+        assertThat(savedTrack.getVolume()).isEqualTo(track.getVolume());
+    }
+
+    @Test
+    @DisplayName("트랙 생성 테스트 - 프로젝트에 이미 10개의 트랙이 포함되어 있는 경우 생성 실패")
+    void testCreateTrack_when_already_over_size_then_throw_exception() {
+        // given
+        TrackCreateRequestDto requestDto = TrackCreateRequestDto.builder()
+                                                                .trackName("test track name")
+                                                                .trackTag(TrackTag.valueOf("PIANO"))
+                                                                .editable(true)
+                                                                .volume(50)
+                                                                .build();
+
+        // when
+        List<Track> tempTracks = new ArrayList<>();
+        for (int i = 0; i < 10; i++) {
+            tempTracks.add(Track.builder().build());
+        }
+        Project projectWithFullTrack = Project.builder()
+                                              .tracks(tempTracks)
+                                              .build();
+
+        // then
+        assertThrows(RuntimeException.class, () -> trackService.create(testMember, projectWithFullTrack, requestDto));
+    }
+}

--- a/server/collusic-be/src/test/java/com/collusic/collusicbe/domain/track/TrackServiceTest.java
+++ b/server/collusic-be/src/test/java/com/collusic/collusicbe/domain/track/TrackServiceTest.java
@@ -37,6 +37,7 @@ public class TrackServiceTest {
 
         testProject = Project.builder()
                              .id(1L)
+                             .tracks(new ArrayList<>())
                              .build();
     }
 
@@ -51,6 +52,8 @@ public class TrackServiceTest {
                                                                 .volume(50)
                                                                 .build();
         Track track = Track.builder()
+                           .creator(testMember)
+                           .project(testProject)
                            .trackName("test track name")
                            .trackTag(TrackTag.PIANO)
                            .editable(true)


### PR DESCRIPTION
## 구현 기능 
트랙 API 구현
- 트랙 생성 : `POST /projects/{projectId}/tracks`
- 트랙 수정 : `PUT /projects/{projectId}/tracks/{trackId}`
- 트랙 삭제 : `DELETE /projects/{projectId}/tracks/{trackId}`


## 논의하고 싶은 내용 
- 개별 트랙에 대한 조회 api는 필요한 시점에 추가 개발하는 것으로 하였습니다.
- Track이 Project 도메인과 밀접한 연관이 있어 Project에 대한 일부 기능을 임시 구현했습니다. 작업하실 때 이어서 구현해주세요
    
Close #229 