### PR TITLE
Fix/232: 애플리케이션 빌드 시 트랙 관련 테스트 실패하는 이슈 해결

### DIFF
--- a/server/collusic-be/src/test/java/com/collusic/collusicbe/domain/track/TrackServiceTest.java
+++ b/server/collusic-be/src/test/java/com/collusic/collusicbe/domain/track/TrackServiceTest.java
@@ -3,6 +3,7 @@ package com.collusic.collusicbe.domain.track;
 import com.collusic.collusicbe.domain.member.Member;
 import com.collusic.collusicbe.domain.project.Project;
 import com.collusic.collusicbe.domain.project.ProjectRepository;
+import com.collusic.collusicbe.global.exception.ForbiddenException;
 import com.collusic.collusicbe.service.TrackService;
 import com.collusic.collusicbe.web.controller.dto.TrackCreateRequestDto;
 import com.collusic.collusicbe.web.controller.dto.TrackUpdateRequestDto;
@@ -155,6 +156,6 @@ public class TrackServiceTest {
         when(trackRepository.findById(any(Long.class))).thenReturn(Optional.of(testTrack));
         doThrow(IllegalStateException.class).when(trackRepository).delete(any(Track.class));
 
-        assertThrows(IllegalStateException.class, () -> trackService.delete(anotherMember, testProject, 1L));
+        assertThrows(ForbiddenException.class, () -> trackService.delete(anotherMember, testProject, 1L));
     }
 }


### PR DESCRIPTION
## 구현 기능 
- 트랙 생성자가 본인이 아닌 트랙을 삭제하려는 경우 Forbidden exception을 던져야하는데 Illegal state exception을 던지도록 테스팅을 하고 있었음
- 기대 예외를 IllegalStateException에서 ForbiddenException으로 변경하여 해결하였음
    
Close #232 
