### PR TITLE
Feat/231: 배포 및 테스트 서버를 위한 도커 설정 완료

### DIFF
--- a/server/collusic-be/Dockerfile-dev
+++ b/server/collusic-be/Dockerfile-dev
@@ -1,0 +1,4 @@
+FROM openjdk:11-jdk
+ADD target/collusic-be-0.0.1-SNAPSHOT.jar collusic-be-0.0.1-SNAPSHOT.jar
+EXPOSE 8080
+ENTRYPOINT ["java", "-Dspring.profiles.active=dev", "-Djava.security.egd=file:/dev/./urandom","-jar","/collusic-be-0.0.1-SNAPSHOT.jar", "-Dcom.amazonaws.sdk.disableEc2Metadata=true"]

--- a/server/collusic-be/docker-compose.yml
+++ b/server/collusic-be/docker-compose.yml
@@ -1,0 +1,23 @@
+version: '3'
+
+services:
+  redis:
+    image: redis
+    container_name: redis
+    ports:
+      - "6379:6379"
+
+  app:
+    restart: always
+    build:
+      context: .
+      dockerfile: Dockerfile-dev
+    ports:
+      - "8080:8080"
+    expose:
+      - "8080"
+    environment:
+      JASYPT_PASSWORD: ${JASYPT_PASSWORD}
+    depends_on:
+      - redis
+    command: mvn clean spring-boot:run -Dspring-boot.run.profiles=dev

--- a/server/collusic-be/run_script.sh
+++ b/server/collusic-be/run_script.sh
@@ -1,0 +1,14 @@
+echo -e "\n\n———— ⛔️ target 폴더 제거 ————\n"
+rm -rf target
+
+echo -e "\n\n———— ⛔️ docker container 삭제 ————\n"
+docker rm $(docker ps -a -q)
+
+echo -e "\n\n———— ⛔️ docker image 삭제 ————\n"
+docker rmi `docker images -a -q`
+
+echo -e "\n\n———— 📦 maven package 파일 생성 ————\n"
+mvn package
+
+echo -e "\n\n———— 🐳 docker container 생성 및 실행 ————\n"
+docker-compose up


### PR DESCRIPTION
## 구현 기능 
- 배포 및 테스트 서버 구동을 위한 도커 파일 및 설정을 추가하였습니다.


## 논의하고 싶은 내용 (optional) 
- 향후 배포 시에도 실행 환경 격리를 위해 도커를 이용한 배포를 할 것 같아서 메인 브랜치에 머지해도 될 것 같아 pr 날립니다.

    
Close #231 
