### PR TITLE
Feat/243 : 액세스 토큰 재발급 API

### DIFF
--- a/server/collusic-be/src/main/java/com/collusic/collusicbe/global/exception/advice/ExceptionControllerAdvice.java
+++ b/server/collusic-be/src/main/java/com/collusic/collusicbe/global/exception/advice/ExceptionControllerAdvice.java
@@ -1,6 +1,7 @@
 package com.collusic.collusicbe.global.exception.advice;
 
 import com.collusic.collusicbe.global.exception.*;
+import io.jsonwebtoken.JwtException;
 import org.springframework.http.HttpStatus;
 import org.springframework.validation.BindException;
 import org.springframework.web.bind.annotation.ExceptionHandler;
@@ -59,5 +60,11 @@ public class ExceptionControllerAdvice {
     @ExceptionHandler(ForbiddenException.class)
     public Object forbiddenExceptionHandler(Exception e) {
         return e.getMessage();
+    }
+
+    @ResponseStatus(HttpStatus.UNAUTHORIZED)
+    @ExceptionHandler(JwtException.class)
+    public Object jwtExceptionHandler(Exception e) {
+        return new ExceptionInfoResponse(HttpStatus.UNAUTHORIZED.getReasonPhrase(), e.getMessage());
     }
 }

--- a/server/collusic-be/src/main/java/com/collusic/collusicbe/global/exception/jwt/TokenNotFoundException.java
+++ b/server/collusic-be/src/main/java/com/collusic/collusicbe/global/exception/jwt/TokenNotFoundException.java
@@ -2,9 +2,9 @@ package com.collusic.collusicbe.global.exception.jwt;
 
 import io.jsonwebtoken.JwtException;
 
-public class AbnormalAccessException extends JwtException {
+public class TokenNotFoundException extends JwtException {
 
-    public AbnormalAccessException(String message) {
+    public TokenNotFoundException(String message) {
         super(message);
     }
 }

--- a/server/collusic-be/src/main/java/com/collusic/collusicbe/web/controller/TokenController.java
+++ b/server/collusic-be/src/main/java/com/collusic/collusicbe/web/controller/TokenController.java
@@ -1,8 +1,8 @@
 package com.collusic.collusicbe.web.controller;
 
 import com.collusic.collusicbe.service.TokenService;
+import com.collusic.collusicbe.util.JWTUtil;
 import com.collusic.collusicbe.util.ParsingUtil;
-import com.collusic.collusicbe.web.controller.dto.TokenResponseDto;
 import io.swagger.v3.oas.annotations.Operation;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
@@ -21,14 +21,16 @@ public class TokenController {
 
     private final TokenService tokenService;
 
-    @Operation(summary = "토큰 재발급", description = "refresh token을 통한 access token, refresh token 재발급")
-    @PostMapping("/tokens/reissue")
-    public ResponseEntity<TokenResponseDto> reissue(@RequestHeader("Authorization") String token, HttpServletRequest request) {
+    @Operation(summary = "토큰 재발급", description = "refresh token을 통한 access token 재발급")
+    @PostMapping("/reissue")
+    public ResponseEntity<String> reissue(@RequestHeader("Authorization") String token, HttpServletRequest request) {
         token = token.substring(BEARER_PREFIX.length());
         String remoteAddress = ParsingUtil.getRemoteAddress(request);
 
+        JWTUtil.verify(token);
+
         return ResponseEntity.status(HttpStatus.CREATED)
-                             .body(tokenService.reissue(token, remoteAddress));
+                             .body(tokenService.reissueAccessToken(token, remoteAddress));
     }
 
     // TODO : refresh token 무효화 api -> 사실상 로그아웃


### PR DESCRIPTION
## 구현 기능 
* 리프레시 토큰을 통한 액세스 토큰 재발급 API 추가

## 공유하고 싶은 내용 (optional) 
* 새로고침 시 로그인 상태 유지를 위해 (프론트엔드 요청)

    
Close #243 
