### PR TITLE
feat/243 : 액세스 토큰 재발급 API

### DIFF
--- a/server/collusic-be/src/main/java/com/collusic/collusicbe/config/SecurityConfig.java
+++ b/server/collusic-be/src/main/java/com/collusic/collusicbe/config/SecurityConfig.java
@@ -38,7 +38,7 @@ public class SecurityConfig extends WebSecurityConfigurerAdapter {
                 .sessionManagement(session -> session.sessionCreationPolicy(SessionCreationPolicy.STATELESS))
                 .formLogin().disable()
                 .authorizeRequests(request -> request.antMatchers(HttpMethod.POST, "/members").permitAll()
-                                                     .antMatchers(HttpMethod.GET, "/oauth2/login/**", "/members/{nickname}").permitAll()
+                                                     .antMatchers(HttpMethod.GET, "/oauth2/login/{provider}", "/members/{nickname}").permitAll()
                                                      .antMatchers("/swagger-ui/**", "/swagger-resources/**", "/v3/api-docs").permitAll()
                                                      .antMatchers(HttpMethod.GET, "/projects/**").permitAll()
                                                      .antMatchers(HttpMethod.OPTIONS, "/**").permitAll()

--- a/server/collusic-be/src/main/java/com/collusic/collusicbe/config/auth/JWTAuthenticationFilter.java
+++ b/server/collusic-be/src/main/java/com/collusic/collusicbe/config/auth/JWTAuthenticationFilter.java
@@ -47,14 +47,28 @@ public class JWTAuthenticationFilter extends BasicAuthenticationFilter {
 
         String bearer = request.getHeader(HttpHeaders.AUTHORIZATION);
 
-        if (bearer == null || !bearer.startsWith(BEARER_PREFIX)) {
+        Cookie[] cookies = Optional.ofNullable(request.getCookies())
+                                   .orElseGet(() -> new Cookie[]{});
+
+        Cookie cookie; // TODO : NoSuch에 대한 예외 처리하기
+
+        cookie = Arrays.stream(cookies)
+                       .filter(c -> c.getName().equals("refreshToken"))
+                       .findFirst()
+                       .orElse(new Cookie("refreshToken", null));
+
+        String refreshToken = cookie.getValue();
+
+        if ((bearer == null || !bearer.startsWith(BEARER_PREFIX)) && refreshToken == null) { // sns 로그인 때문에 넣음. 의도적으로 액세스 토큰을 넣지 않은건지, 아니면 액세스 토큰이 없는건지.
             chain.doFilter(request, response);
             return;
         }
 
-        String token = bearer.substring(BEARER_PREFIX.length());
+        String token;
 
         try {
+            token = bearer.substring(BEARER_PREFIX.length());
+
             JWTAuthenticationToken authenticationToken = new JWTAuthenticationToken(token, Set.of(new SimpleGrantedAuthority(JWTUtil.getRole(token)))); // TODO: JWT 형식이 아닌 토큰이 들어왔을 때 예외가 예상되는 부분. 해결이 필요함.
             Authentication authentication = this.authenticationManager.authenticate(authenticationToken);
 
@@ -62,7 +76,7 @@ public class JWTAuthenticationFilter extends BasicAuthenticationFilter {
                                  .setAuthentication(authentication);
 
             chain.doFilter(request, response);
-        } catch (ExpiredJwtException e) {
+        } catch (ExpiredJwtException | NullPointerException e) {
             token = reissueAccessToken(request, response);
 
             JWTAuthenticationToken authenticationToken = new JWTAuthenticationToken(token, Set.of(new SimpleGrantedAuthority(JWTUtil.getRole(token)))); // TODO: JWT 형식이 아닌 토큰이 들어왔을 때 예외가 예상되는 부분. 해결이 필요함.

--- a/server/collusic-be/src/main/java/com/collusic/collusicbe/service/TokenService.java
+++ b/server/collusic-be/src/main/java/com/collusic/collusicbe/service/TokenService.java
@@ -28,8 +28,7 @@ public class TokenService {
         String accessToken = JWTUtil.createAccessToken(email, role);
         String refreshToken = JWTUtil.createRefreshToken(email, role);
 
-        long time = 30L;
-        redisRepository.save(refreshToken, remoteAddress, Duration.ofSeconds(time));
+        redisRepository.save(refreshToken, remoteAddress, Duration.ofSeconds(REFRESH_TIME));
 
         return new TokenResponseDto(accessToken, refreshToken);
     }

--- a/server/collusic-be/src/main/java/com/collusic/collusicbe/web/controller/TokenController.java
+++ b/server/collusic-be/src/main/java/com/collusic/collusicbe/web/controller/TokenController.java
@@ -1,17 +1,14 @@
 package com.collusic.collusicbe.web.controller;
 
-import com.collusic.collusicbe.service.TokenService;
 import com.collusic.collusicbe.util.JWTUtil;
-import com.collusic.collusicbe.util.ParsingUtil;
 import io.swagger.v3.oas.annotations.Operation;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.PostMapping;
-import org.springframework.web.bind.annotation.RequestHeader;
 import org.springframework.web.bind.annotation.RestController;
 
-import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
 
 @RequiredArgsConstructor
 @RestController
@@ -19,18 +16,15 @@ public class TokenController {
 
     private final static String BEARER_PREFIX = "Bearer ";
 
-    private final TokenService tokenService;
-
     @Operation(summary = "토큰 재발급", description = "refresh token을 통한 access token 재발급")
     @PostMapping("/reissue")
-    public ResponseEntity<String> reissue(@RequestHeader("Authorization") String token, HttpServletRequest request) {
-        token = token.substring(BEARER_PREFIX.length());
-        String remoteAddress = ParsingUtil.getRemoteAddress(request);
-
-        JWTUtil.verify(token);
-
+    public ResponseEntity<String> reissue(HttpServletResponse response) {
+        String bearer = response.getHeader("Authorization");
+        String token = bearer.substring(BEARER_PREFIX.length());
+        String accessToken = JWTUtil.createAccessToken(JWTUtil.getEmail(token), JWTUtil.getRole(token));
+        response.setHeader("Authorization", BEARER_PREFIX + accessToken);
         return ResponseEntity.status(HttpStatus.CREATED)
-                             .body(tokenService.reissueAccessToken(token, remoteAddress));
+                             .body(accessToken);
     }
 
     // TODO : refresh token 무효화 api -> 사실상 로그아웃

--- a/server/collusic-be/src/main/java/com/collusic/collusicbe/web/controller/dto/ReissuedTokenDto.java
+++ b/server/collusic-be/src/main/java/com/collusic/collusicbe/web/controller/dto/ReissuedTokenDto.java
@@ -1,0 +1,10 @@
+package com.collusic.collusicbe.web.controller.dto;
+
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+@Getter
+@RequiredArgsConstructor
+public class ReissuedTokenDto {
+    private final String token;
+}


### PR DESCRIPTION
## 구현 기능 
* 프론트엔드 요구사항 변경에 따른 액세스 토큰 재발급 API 수정


## 논의하고 싶은 내용 (optional) 
- 액세스 토큰이 필요하지 않은 경우에 대한 접근(SNS 소셜 회원가입의 경우)
- 액세스 토큰이 빠져있는 경우에 대한 접근(액세스 토큰이 요청으로 들어오지 않은 경우에 대한 접근)

## 공유하고 싶은 내용 (optional) 
* 긴급으로 구현. 코드 리팩토링 예정

    
Close #243 
