### PR TITLE
Fix/246 : CORS 문제 해결(토큰 재발급 필터 수정)

### DIFF
--- a/server/collusic-be/src/main/java/com/collusic/collusicbe/config/SecurityConfig.java
+++ b/server/collusic-be/src/main/java/com/collusic/collusicbe/config/SecurityConfig.java
@@ -4,7 +4,6 @@ import com.collusic.collusicbe.config.auth.ExceptionHandlerFilter;
 import com.collusic.collusicbe.config.auth.JWTAuthenticationFilter;
 import com.collusic.collusicbe.config.auth.JWTAuthenticationProvider;
 import com.collusic.collusicbe.service.TokenService;
-import com.fasterxml.jackson.databind.ObjectMapper;
 import lombok.RequiredArgsConstructor;
 import org.springframework.boot.autoconfigure.security.servlet.PathRequest;
 import org.springframework.context.annotation.Bean;
@@ -28,7 +27,6 @@ public class SecurityConfig extends WebSecurityConfigurerAdapter {
     private final JWTAuthenticationProvider jwtAuthenticationProvider;
     private final AuthenticationEntryPoint jwtAuthenticationEntryPoint;
     private final TokenService tokenService;
-    private final ObjectMapper objectMapper;
     private final ExceptionHandlerFilter exceptionHandlerFilter;
 
     @Override
@@ -44,7 +42,7 @@ public class SecurityConfig extends WebSecurityConfigurerAdapter {
                                                      .antMatchers(HttpMethod.OPTIONS, "/**").permitAll()
                                                      .anyRequest().authenticated())
                 .exceptionHandling().authenticationEntryPoint(jwtAuthenticationEntryPoint).and()
-                .addFilterAt(new JWTAuthenticationFilter(authenticationManager(), tokenService, objectMapper), BasicAuthenticationFilter.class)
+                .addFilterAt(new JWTAuthenticationFilter(authenticationManager(), tokenService), BasicAuthenticationFilter.class)
                 .addFilterBefore(exceptionHandlerFilter, JWTAuthenticationFilter.class);
     }
 

--- a/server/collusic-be/src/main/java/com/collusic/collusicbe/config/SecurityConfig.java
+++ b/server/collusic-be/src/main/java/com/collusic/collusicbe/config/SecurityConfig.java
@@ -38,7 +38,7 @@ public class SecurityConfig extends WebSecurityConfigurerAdapter {
                 .sessionManagement(session -> session.sessionCreationPolicy(SessionCreationPolicy.STATELESS))
                 .formLogin().disable()
                 .authorizeRequests(request -> request.antMatchers(HttpMethod.POST, "/members").permitAll()
-                                                     .antMatchers(HttpMethod.GET, "/oauth2/login/**", "/members/{nickname}").permitAll()
+                                                     .antMatchers(HttpMethod.GET, "/oauth2/login/{provider}", "/members/{nickname}").permitAll()
                                                      .antMatchers("/swagger-ui/**", "/swagger-resources/**", "/v3/api-docs").permitAll()
                                                      .antMatchers(HttpMethod.GET, "/projects/**").permitAll()
                                                      .antMatchers(HttpMethod.OPTIONS, "/**").permitAll()

--- a/server/collusic-be/src/main/java/com/collusic/collusicbe/config/auth/ExceptionHandlerFilter.java
+++ b/server/collusic-be/src/main/java/com/collusic/collusicbe/config/auth/ExceptionHandlerFilter.java
@@ -3,7 +3,7 @@ package com.collusic.collusicbe.config.auth;
 import com.collusic.collusicbe.global.exception.ExceptionInfoResponse;
 import com.collusic.collusicbe.global.exception.UnAuthorizedException;
 import com.collusic.collusicbe.global.exception.jwt.AbnormalAccessException;
-import com.collusic.collusicbe.global.exception.jwt.ExpiredJwtException;
+import com.collusic.collusicbe.global.exception.jwt.ExpiredTokenException;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
@@ -30,7 +30,7 @@ public class ExceptionHandlerFilter extends OncePerRequestFilter {
 
         try {
             filterChain.doFilter(request, response);
-        } catch (ExpiredJwtException | AbnormalAccessException | EntityNotFoundException | UnAuthorizedException e) {
+        } catch (ExpiredTokenException | AbnormalAccessException | EntityNotFoundException | UnAuthorizedException e) {
             expireCookie(response, "refreshToken");
             SecurityContextHolder.clearContext();
             sendErrorResponse(HttpStatus.UNAUTHORIZED.value(), response, e);

--- a/server/collusic-be/src/main/java/com/collusic/collusicbe/config/auth/ExceptionHandlerFilter.java
+++ b/server/collusic-be/src/main/java/com/collusic/collusicbe/config/auth/ExceptionHandlerFilter.java
@@ -7,6 +7,8 @@ import com.collusic.collusicbe.global.exception.jwt.ExpiredJwtException;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.security.web.authentication.logout.CookieClearingLogoutHandler;
 import org.springframework.stereotype.Component;
 import org.springframework.web.filter.OncePerRequestFilter;
 
@@ -22,6 +24,7 @@ import java.io.IOException;
 public class ExceptionHandlerFilter extends OncePerRequestFilter {
 
     private final ObjectMapper objectMapper;
+    private final CookieClearingLogoutHandler cookieClearingLogoutHandler;
 
     @Override
     protected void doFilterInternal(HttpServletRequest request, HttpServletResponse response, FilterChain filterChain) throws ServletException, IOException {
@@ -29,6 +32,8 @@ public class ExceptionHandlerFilter extends OncePerRequestFilter {
         try {
             filterChain.doFilter(request, response);
         } catch (ExpiredJwtException | AbnormalAccessException | EntityNotFoundException | UnAuthorizedException e) {
+            cookieClearingLogoutHandler.logout(request, response, SecurityContextHolder.getContext().getAuthentication());
+            SecurityContextHolder.clearContext();
             sendErrorResponse(HttpStatus.UNAUTHORIZED.value(), response, e);
         }
     }

--- a/server/collusic-be/src/main/java/com/collusic/collusicbe/config/auth/ExceptionHandlerFilter.java
+++ b/server/collusic-be/src/main/java/com/collusic/collusicbe/config/auth/ExceptionHandlerFilter.java
@@ -8,13 +8,13 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
 import org.springframework.security.core.context.SecurityContextHolder;
-import org.springframework.security.web.authentication.logout.CookieClearingLogoutHandler;
 import org.springframework.stereotype.Component;
 import org.springframework.web.filter.OncePerRequestFilter;
 
 import javax.persistence.EntityNotFoundException;
 import javax.servlet.FilterChain;
 import javax.servlet.ServletException;
+import javax.servlet.http.Cookie;
 import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
 import java.io.IOException;
@@ -24,7 +24,6 @@ import java.io.IOException;
 public class ExceptionHandlerFilter extends OncePerRequestFilter {
 
     private final ObjectMapper objectMapper;
-    private final CookieClearingLogoutHandler cookieClearingLogoutHandler;
 
     @Override
     protected void doFilterInternal(HttpServletRequest request, HttpServletResponse response, FilterChain filterChain) throws ServletException, IOException {
@@ -32,10 +31,16 @@ public class ExceptionHandlerFilter extends OncePerRequestFilter {
         try {
             filterChain.doFilter(request, response);
         } catch (ExpiredJwtException | AbnormalAccessException | EntityNotFoundException | UnAuthorizedException e) {
-            cookieClearingLogoutHandler.logout(request, response, SecurityContextHolder.getContext().getAuthentication());
+            expireCookie(response, "refreshToken");
             SecurityContextHolder.clearContext();
             sendErrorResponse(HttpStatus.UNAUTHORIZED.value(), response, e);
         }
+    }
+
+    private void expireCookie(HttpServletResponse response, String cookieName) {
+        Cookie cookie = new Cookie(cookieName, null);
+        cookie.setMaxAge(0);
+        response.addCookie(cookie);
     }
 
     private void sendErrorResponse(int status, HttpServletResponse response, RuntimeException e) throws IOException {

--- a/server/collusic-be/src/main/java/com/collusic/collusicbe/config/auth/JWTAuthenticationFilter.java
+++ b/server/collusic-be/src/main/java/com/collusic/collusicbe/config/auth/JWTAuthenticationFilter.java
@@ -1,11 +1,9 @@
 package com.collusic.collusicbe.config.auth;
 
-import com.collusic.collusicbe.global.exception.UnAuthorizedException;
 import com.collusic.collusicbe.global.exception.jwt.AbnormalAccessException;
 import com.collusic.collusicbe.service.TokenService;
 import com.collusic.collusicbe.util.JWTUtil;
 import com.collusic.collusicbe.util.ParsingUtil;
-import com.fasterxml.jackson.databind.ObjectMapper;
 import io.jsonwebtoken.ExpiredJwtException;
 import org.springframework.http.HttpHeaders;
 import org.springframework.security.authentication.AuthenticationManager;
@@ -33,13 +31,10 @@ public class JWTAuthenticationFilter extends BasicAuthenticationFilter {
 
     private final TokenService tokenService;
 
-    private final ObjectMapper objectMapper;
-
-    public JWTAuthenticationFilter(AuthenticationManager authenticationManager, TokenService tokenService, ObjectMapper objectMapper) {
+    public JWTAuthenticationFilter(AuthenticationManager authenticationManager, TokenService tokenService) {
         super(authenticationManager);
         this.authenticationManager = authenticationManager;
         this.tokenService = tokenService;
-        this.objectMapper = objectMapper;
     }
 
     @Override
@@ -47,61 +42,55 @@ public class JWTAuthenticationFilter extends BasicAuthenticationFilter {
 
         String bearer = request.getHeader(HttpHeaders.AUTHORIZATION);
 
-        if (bearer == null || !bearer.startsWith(BEARER_PREFIX)) {
+        String refreshToken = extractRefreshToken(request);
+
+        if ((bearer == null || !bearer.startsWith(BEARER_PREFIX)) && refreshToken == null) {
             chain.doFilter(request, response);
             return;
         }
 
-        String token = bearer.substring(BEARER_PREFIX.length());
-
         try {
-            JWTAuthenticationToken authenticationToken = new JWTAuthenticationToken(token, Set.of(new SimpleGrantedAuthority(JWTUtil.getRole(token)))); // TODO: JWT 형식이 아닌 토큰이 들어왔을 때 예외가 예상되는 부분. 해결이 필요함.
+            if (bearer == null || !bearer.startsWith(BEARER_PREFIX)) {
+                throw new NullPointerException();
+            }
+
+            String token = bearer.substring(BEARER_PREFIX.length());
+
+            JWTAuthenticationToken authenticationToken = new JWTAuthenticationToken(token, Set.of(new SimpleGrantedAuthority(JWTUtil.getRole(token))));
             Authentication authentication = this.authenticationManager.authenticate(authenticationToken);
 
             SecurityContextHolder.getContext()
                                  .setAuthentication(authentication);
 
             chain.doFilter(request, response);
-        } catch (ExpiredJwtException e) {
-            token = reissueAccessToken(request, response);
+        } catch (ExpiredJwtException | NullPointerException accessExpiredException) {
+            try {
+                JWTAuthenticationToken authenticationToken = new JWTAuthenticationToken(refreshToken, Set.of(new SimpleGrantedAuthority(JWTUtil.getRole(refreshToken))));
+                Authentication authentication = this.authenticationManager.authenticate(authenticationToken);
 
-            JWTAuthenticationToken authenticationToken = new JWTAuthenticationToken(token, Set.of(new SimpleGrantedAuthority(JWTUtil.getRole(token)))); // TODO: JWT 형식이 아닌 토큰이 들어왔을 때 예외가 예상되는 부분. 해결이 필요함.
-            Authentication authentication = this.authenticationManager.authenticate(authenticationToken);
+                String token = tokenService.reissueAccessToken(refreshToken, ParsingUtil.getRemoteAddress(request));
+                response.setHeader("Authorization", BEARER_PREFIX + token);
 
-            SecurityContextHolder.getContext()
-                                 .setAuthentication(authentication);
+                SecurityContextHolder.getContext()
+                                     .setAuthentication(authentication);
 
-            chain.doFilter(request, response);
+                chain.doFilter(request, response);
+            } catch (ExpiredJwtException | EntityNotFoundException | AbnormalAccessException refreshExpiredException) {
+                tokenService.deleteRefreshToken(refreshToken);
+                throw refreshExpiredException;
+            }
         }
     }
 
-    private String reissueAccessToken(HttpServletRequest request, HttpServletResponse response) {
-
+    private String extractRefreshToken(HttpServletRequest request) {
         Cookie[] cookies = Optional.ofNullable(request.getCookies())
                                    .orElseGet(() -> new Cookie[]{});
 
-        Cookie cookie; // TODO : NoSuch에 대한 예외 처리하기
+        Cookie cookie = Arrays.stream(cookies)
+                              .filter(c -> c.getName().equals("refreshToken"))
+                              .findFirst()
+                              .orElse(new Cookie("refreshToken", null));
 
-        cookie = Arrays.stream(cookies)
-                       .filter(c -> c.getName().equals("refreshToken"))
-                       .findFirst()
-                       .orElseThrow(UnAuthorizedException::new);
-
-        String refreshToken = cookie.getValue();
-
-        try {
-            JWTUtil.verify(refreshToken);
-
-            String accessToken = tokenService.reissueAccessToken(refreshToken, ParsingUtil.getRemoteAddress(request));
-            response.setHeader("Authorization", BEARER_PREFIX + accessToken);
-
-            return accessToken;
-        } catch (ExpiredJwtException | EntityNotFoundException e) {
-            throw e;
-        } catch (AbnormalAccessException e) {
-            tokenService.deleteRefreshToken(refreshToken);
-            throw e;
-        }
-
+        return cookie.getValue();
     }
 }

--- a/server/collusic-be/src/main/java/com/collusic/collusicbe/config/auth/JWTAuthenticationFilter.java
+++ b/server/collusic-be/src/main/java/com/collusic/collusicbe/config/auth/JWTAuthenticationFilter.java
@@ -4,7 +4,7 @@ import com.collusic.collusicbe.global.exception.jwt.AbnormalAccessException;
 import com.collusic.collusicbe.service.TokenService;
 import com.collusic.collusicbe.util.JWTUtil;
 import com.collusic.collusicbe.util.ParsingUtil;
-import io.jsonwebtoken.ExpiredJwtException;
+import com.collusic.collusicbe.global.exception.jwt.ExpiredTokenException;
 import org.springframework.http.HttpHeaders;
 import org.springframework.security.authentication.AuthenticationManager;
 import org.springframework.security.core.Authentication;
@@ -38,7 +38,7 @@ public class JWTAuthenticationFilter extends BasicAuthenticationFilter {
     }
 
     @Override
-    protected void doFilterInternal(HttpServletRequest request, HttpServletResponse response, FilterChain chain) throws IOException, ServletException {
+    protected void doFilterInternal(HttpServletRequest request, HttpServletResponse response, FilterChain chain) throws IOException, ServletException, ExpiredTokenException {
 
         String bearer = request.getHeader(HttpHeaders.AUTHORIZATION);
 
@@ -63,7 +63,7 @@ public class JWTAuthenticationFilter extends BasicAuthenticationFilter {
                                  .setAuthentication(authentication);
 
             chain.doFilter(request, response);
-        } catch (ExpiredJwtException | NullPointerException accessExpiredException) {
+        } catch (ExpiredTokenException | NullPointerException e) {
             authenticateWithRefreshToken(request, response, chain, refreshToken);
         }
     }
@@ -80,9 +80,9 @@ public class JWTAuthenticationFilter extends BasicAuthenticationFilter {
                                  .setAuthentication(authentication);
 
             chain.doFilter(request, response);
-        } catch (ExpiredJwtException | EntityNotFoundException | AbnormalAccessException refreshExpiredException) {
+        } catch (ExpiredTokenException | EntityNotFoundException | AbnormalAccessException e) {
             tokenService.deleteRefreshToken(refreshToken);
-            throw refreshExpiredException;
+            throw e;
         }
     }
 

--- a/server/collusic-be/src/main/java/com/collusic/collusicbe/config/auth/JWTAuthenticationProvider.java
+++ b/server/collusic-be/src/main/java/com/collusic/collusicbe/config/auth/JWTAuthenticationProvider.java
@@ -1,5 +1,5 @@
 package com.collusic.collusicbe.config.auth;
-import com.collusic.collusicbe.global.exception.jwt.ExpiredJwtException;
+import com.collusic.collusicbe.global.exception.jwt.ExpiredTokenException;
 import com.collusic.collusicbe.util.JWTUtil;
 import org.springframework.security.authentication.AuthenticationProvider;
 import org.springframework.security.core.Authentication;
@@ -10,7 +10,7 @@ import org.springframework.stereotype.Component;
 public class JWTAuthenticationProvider implements AuthenticationProvider {
 
     @Override
-    public Authentication authenticate(Authentication authentication) throws AuthenticationException, ExpiredJwtException {
+    public Authentication authenticate(Authentication authentication) throws AuthenticationException, ExpiredTokenException {
         String token = (String) authentication.getPrincipal();
 
         JWTUtil.verify(token);

--- a/server/collusic-be/src/main/java/com/collusic/collusicbe/global/exception/jwt/ExpiredTokenException.java
+++ b/server/collusic-be/src/main/java/com/collusic/collusicbe/global/exception/jwt/ExpiredTokenException.java
@@ -2,9 +2,9 @@ package com.collusic.collusicbe.global.exception.jwt;
 
 import io.jsonwebtoken.JwtException;
 
-public class ExpiredJwtException extends JwtException {
+public class ExpiredTokenException extends JwtException {
 
-    public ExpiredJwtException(String message) {
+    public ExpiredTokenException(String message) {
         super(message);
     }
 }

--- a/server/collusic-be/src/main/java/com/collusic/collusicbe/service/TokenService.java
+++ b/server/collusic-be/src/main/java/com/collusic/collusicbe/service/TokenService.java
@@ -6,7 +6,6 @@ import com.collusic.collusicbe.web.controller.dto.TokenResponseDto;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 
-import javax.persistence.EntityNotFoundException;
 import java.time.Duration;
 
 import static com.collusic.collusicbe.util.JWTUtil.REFRESH_TIME;
@@ -38,10 +37,6 @@ public class TokenService {
     }
 
     public String reissueAccessToken(String refreshToken, String remoteAddress) {
-
-        if (!redisRepository.hasKey(refreshToken)) {
-            throw new EntityNotFoundException("토큰이 존재하지 않습니다.");
-        }
 
         if (!redisRepository.findByKey(refreshToken).equals(remoteAddress)) {
             throw new AbnormalAccessException("사용자의 IP 주소가 다릅니다.");

--- a/server/collusic-be/src/main/java/com/collusic/collusicbe/service/TokenService.java
+++ b/server/collusic-be/src/main/java/com/collusic/collusicbe/service/TokenService.java
@@ -28,8 +28,7 @@ public class TokenService {
         String accessToken = JWTUtil.createAccessToken(email, role);
         String refreshToken = JWTUtil.createRefreshToken(email, role);
 
-        long time = 30L;
-        redisRepository.save(refreshToken, remoteAddress, Duration.ofSeconds(time));
+        redisRepository.save(refreshToken, remoteAddress, Duration.ofSeconds(REFRESH_TIME));
 
         return new TokenResponseDto(accessToken, refreshToken);
     }

--- a/server/collusic-be/src/main/java/com/collusic/collusicbe/service/TokenService.java
+++ b/server/collusic-be/src/main/java/com/collusic/collusicbe/service/TokenService.java
@@ -44,7 +44,7 @@ public class TokenService {
         }
 
         if (!redisRepository.findByKey(refreshToken).equals(remoteAddress)) {
-            throw new AbnormalAccessException("사용자의 IP 주소가 다릅니다."); // TODO: 비정상적인 접근으로 redis에서 refreshtoken을 지워줘야함
+            throw new AbnormalAccessException("사용자의 IP 주소가 다릅니다.");
         }
 
         String email = JWTUtil.getEmail(refreshToken);

--- a/server/collusic-be/src/main/java/com/collusic/collusicbe/util/JWTUtil.java
+++ b/server/collusic-be/src/main/java/com/collusic/collusicbe/util/JWTUtil.java
@@ -1,9 +1,9 @@
 package com.collusic.collusicbe.util;
 
+import com.collusic.collusicbe.global.exception.jwt.ExpiredTokenException;
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import io.jsonwebtoken.*;
-import com.collusic.collusicbe.global.exception.jwt.ExpiredJwtException;
 import lombok.extern.slf4j.Slf4j;
 
 import java.time.Instant;
@@ -36,7 +36,7 @@ public class JWTUtil {
                        .getBody();
         } catch (ExpiredJwtException e) {
             log.info("토큰 만료");
-            throw new ExpiredJwtException("토큰 만료");
+            throw new ExpiredTokenException("토큰 만료");
         } catch (UnsupportedJwtException e) {
             log.info("애플리케이션에서 지원하지 않는 토큰 형식");
             throw new UnsupportedJwtException("애플리케이션에서 지원하지 않는 토큰 형식");
@@ -57,7 +57,7 @@ public class JWTUtil {
                    .setHeader(jwtHeaders())
                    .claim("email", email)
                    .claim("role", role)
-                   .claim("exp", Instant.now().getEpochSecond() + REFRESH_TIME)
+                   .claim("exp", Instant.now().getEpochSecond() + 1)
                    .signWith(SignatureAlgorithm.HS256, KEY)
                    .compact();
     }

--- a/server/collusic-be/src/main/java/com/collusic/collusicbe/util/JWTUtil.java
+++ b/server/collusic-be/src/main/java/com/collusic/collusicbe/util/JWTUtil.java
@@ -57,7 +57,7 @@ public class JWTUtil {
                    .setHeader(jwtHeaders())
                    .claim("email", email)
                    .claim("role", role)
-                   .claim("exp", Instant.now().getEpochSecond() + 1)
+                   .claim("exp", Instant.now().getEpochSecond() + REFRESH_TIME)
                    .signWith(SignatureAlgorithm.HS256, KEY)
                    .compact();
     }

--- a/server/collusic-be/src/main/java/com/collusic/collusicbe/web/controller/TokenController.java
+++ b/server/collusic-be/src/main/java/com/collusic/collusicbe/web/controller/TokenController.java
@@ -1,10 +1,7 @@
 package com.collusic.collusicbe.web.controller;
 
-<<<<<<< HEAD
 import com.collusic.collusicbe.web.controller.dto.ReissuedTokenDto;
-=======
-import com.collusic.collusicbe.util.JWTUtil;
->>>>>>> dev-be
+
 import io.swagger.v3.oas.annotations.Operation;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
@@ -22,21 +19,11 @@ public class TokenController {
 
     @Operation(summary = "토큰 재발급", description = "refresh token을 통한 access token 재발급")
     @PostMapping("/reissue")
-<<<<<<< HEAD
     public ResponseEntity<ReissuedTokenDto> reissue(HttpServletResponse response) {
         String bearer = response.getHeader("Authorization");
         String accessToken = bearer.substring(BEARER_PREFIX.length());
         response.setHeader("Authorization", null);
         return ResponseEntity.status(HttpStatus.CREATED)
                              .body(new ReissuedTokenDto(accessToken));
-=======
-    public ResponseEntity<String> reissue(HttpServletResponse response) {
-        String bearer = response.getHeader("Authorization");
-        String token = bearer.substring(BEARER_PREFIX.length());
-        String accessToken = JWTUtil.createAccessToken(JWTUtil.getEmail(token), JWTUtil.getRole(token));
-        response.setHeader("Authorization", BEARER_PREFIX + accessToken);
-        return ResponseEntity.status(HttpStatus.CREATED)
-                             .body(accessToken);
->>>>>>> dev-be
     }
 }

--- a/server/collusic-be/src/main/java/com/collusic/collusicbe/web/controller/TokenController.java
+++ b/server/collusic-be/src/main/java/com/collusic/collusicbe/web/controller/TokenController.java
@@ -1,6 +1,5 @@
 package com.collusic.collusicbe.web.controller;
 
-import com.collusic.collusicbe.util.JWTUtil;
 import com.collusic.collusicbe.web.controller.dto.ReissuedTokenDto;
 import io.swagger.v3.oas.annotations.Operation;
 import lombok.RequiredArgsConstructor;
@@ -21,12 +20,9 @@ public class TokenController {
     @PostMapping("/reissue")
     public ResponseEntity<ReissuedTokenDto> reissue(HttpServletResponse response) {
         String bearer = response.getHeader("Authorization");
-        String token = bearer.substring(BEARER_PREFIX.length());
-        String accessToken = JWTUtil.createAccessToken(JWTUtil.getEmail(token), JWTUtil.getRole(token));
-        response.setHeader("Authorization", BEARER_PREFIX + accessToken);
+        String accessToken = bearer.substring(BEARER_PREFIX.length());
+        response.setHeader("Authorization", null);
         return ResponseEntity.status(HttpStatus.CREATED)
                              .body(new ReissuedTokenDto(accessToken));
     }
-
-    // TODO : refresh token 무효화 api -> 사실상 로그아웃
 }

--- a/server/collusic-be/src/main/java/com/collusic/collusicbe/web/controller/TokenController.java
+++ b/server/collusic-be/src/main/java/com/collusic/collusicbe/web/controller/TokenController.java
@@ -1,17 +1,15 @@
 package com.collusic.collusicbe.web.controller;
 
-import com.collusic.collusicbe.service.TokenService;
 import com.collusic.collusicbe.util.JWTUtil;
-import com.collusic.collusicbe.util.ParsingUtil;
+import com.collusic.collusicbe.web.controller.dto.ReissuedTokenDto;
 import io.swagger.v3.oas.annotations.Operation;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.PostMapping;
-import org.springframework.web.bind.annotation.RequestHeader;
 import org.springframework.web.bind.annotation.RestController;
 
-import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
 
 @RequiredArgsConstructor
 @RestController
@@ -19,18 +17,15 @@ public class TokenController {
 
     private final static String BEARER_PREFIX = "Bearer ";
 
-    private final TokenService tokenService;
-
     @Operation(summary = "토큰 재발급", description = "refresh token을 통한 access token 재발급")
     @PostMapping("/reissue")
-    public ResponseEntity<String> reissue(@RequestHeader("Authorization") String token, HttpServletRequest request) {
-        token = token.substring(BEARER_PREFIX.length());
-        String remoteAddress = ParsingUtil.getRemoteAddress(request);
-
-        JWTUtil.verify(token);
-
+    public ResponseEntity<ReissuedTokenDto> reissue(HttpServletResponse response) {
+        String bearer = response.getHeader("Authorization");
+        String token = bearer.substring(BEARER_PREFIX.length());
+        String accessToken = JWTUtil.createAccessToken(JWTUtil.getEmail(token), JWTUtil.getRole(token));
+        response.setHeader("Authorization", BEARER_PREFIX + accessToken);
         return ResponseEntity.status(HttpStatus.CREATED)
-                             .body(tokenService.reissueAccessToken(token, remoteAddress));
+                             .body(new ReissuedTokenDto(accessToken));
     }
 
     // TODO : refresh token 무효화 api -> 사실상 로그아웃

--- a/server/collusic-be/src/main/java/com/collusic/collusicbe/web/controller/dto/ReissuedTokenDto.java
+++ b/server/collusic-be/src/main/java/com/collusic/collusicbe/web/controller/dto/ReissuedTokenDto.java
@@ -1,0 +1,10 @@
+package com.collusic.collusicbe.web.controller.dto;
+
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+@Getter
+@RequiredArgsConstructor
+public class ReissuedTokenDto {
+    private final String token;
+}


### PR DESCRIPTION
## 구현 기능 
* 토큰 재발급 API 수정

## 공유하고 싶은 내용 (optional) 
* 액세스 토큰 만료 상황에서 리프레시 토큰을 통한 액세스 토큰 재발급
* 리프레시 토큰 만료 상황에서 세션 무효화, 쿠키 제거, SecurityContext 비우기
* io.jsonwebtoken.ExpiredJwtException과 커스텀 Exception의 네임이 같은 문제로 디버거가 네임 구별을 못하는 문제 발생하여 이를 해결했습니다.

Close #246
