### PR TITLE
fix : 로그아웃 기능 버그 해결

### DIFF
--- a/server/collusic-be/src/main/java/com/collusic/collusicbe/config/SecurityConfig.java
+++ b/server/collusic-be/src/main/java/com/collusic/collusicbe/config/SecurityConfig.java
@@ -35,6 +35,7 @@ public class SecurityConfig extends WebSecurityConfigurerAdapter {
                 .csrf().disable()
                 .sessionManagement(session -> session.sessionCreationPolicy(SessionCreationPolicy.STATELESS))
                 .formLogin().disable()
+                .logout().disable()
                 .authorizeRequests(request -> request.antMatchers(HttpMethod.POST, "/members").permitAll()
                                                      .antMatchers(HttpMethod.GET, "/oauth2/login/{provider}", "/members/{nickname}").permitAll()
                                                      .antMatchers("/swagger-ui/**", "/swagger-resources/**", "/v3/api-docs").permitAll()


### PR DESCRIPTION
## 구현 기능 
* SpringSecurityConfig logout disable

## 공유하고 싶은 내용 (optional) 
*  SpringSecurityConfig logout disable을 하지 않을 경우 시큐리티 내부에서 http://localhost:8080/login?logout 으로 리다이렉트 처리하는 것으로 보입니다.

    
Close #253 
