### PR TITLE
feat/300: 재생 막대 바 및 트랙 편집 영역 구현

### DIFF
--- a/client/.eslintrc.js
+++ b/client/.eslintrc.js
@@ -21,5 +21,8 @@ module.exports = {
     "jsx-a11y/media-has-caption": 0,
     "no-unused-expressions": ["error", { allowShortCircuit: true }],
     "react/react-in-jsx-scope": 0,
+    "jsx-a11y/no-static-element-interactions": 0,
+    "no-console": 0,
+    "no-alert": 0,
   },
 };

--- a/client/src/App.tsx
+++ b/client/src/App.tsx
@@ -6,6 +6,7 @@ import { SignUpViewModel } from "viewmodel/SignUpViewModel";
 import { RedirectViewModel } from "viewmodel/RedirectViewModel";
 import CreateProjectPage from "components/pages/CreateProjectPage";
 import ProjectListPage from "components/pages/ProjectListPage";
+import ProjectSettingViewModel from "./viewmodel/ProjectSettingViewModel";
 
 function App() {
   return (
@@ -17,6 +18,7 @@ function App() {
         <Route path="/signin" element={<SignInViewModel />} />
         <Route path="/signup" element={<SignUpViewModel />} />
         <Route path="/auth/redirect/:snsType" element={<RedirectViewModel />} />
+        <Route path="/detailProject/:projectId" element={<ProjectSettingViewModel />} />
       </Routes>
     </BrowserRouter>
   );

--- a/client/src/components/blocks/PlayStick/index.tsx
+++ b/client/src/components/blocks/PlayStick/index.tsx
@@ -1,0 +1,12 @@
+import "./style.scss";
+
+function PlayStick({ currentOffset, currentRef }: any) {
+  return (
+    <div id="play-stick" ref={currentRef} style={{ left: currentOffset }}>
+      <div id="handle" />
+      <div id="stick" />
+    </div>
+  );
+}
+
+export default PlayStick;

--- a/client/src/components/blocks/PlayStick/style.scss
+++ b/client/src/components/blocks/PlayStick/style.scss
@@ -1,0 +1,22 @@
+#play-stick {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  position: relative;
+  width: 12px;
+  height: 100%;
+
+  #handle {
+    width: 12px;
+    height: 12px;
+    border-radius: 24px;
+    background-color: #b1ff00;
+  }
+
+  #stick {
+    width: 2px;
+    height: 100%;
+    border-radius: 5px;
+    background-color: #b1ff00;
+  }
+}

--- a/client/src/components/blocks/ProjectSetting/index.tsx
+++ b/client/src/components/blocks/ProjectSetting/index.tsx
@@ -1,4 +1,4 @@
-import { FormEventHandler, MouseEventHandler } from "react";
+import { Dispatch, FormEventHandler, MouseEventHandler, SetStateAction } from "react";
 
 import { Track } from "types/projectType";
 import Button from "components/atoms/Button";
@@ -6,6 +6,7 @@ import Bpm from "components/blocks/BpmBar";
 import RecordDevice from "../RecordDevice";
 import TrackTag from "../TrackTag";
 import "./style.scss";
+import TrackSpace from "../TrackSpace";
 
 interface ProjectSettingProps {
   onDeviceClick: (deviceId: string, deviceName: string) => void;
@@ -17,6 +18,8 @@ interface ProjectSettingProps {
   selectedTrack: Track;
   tracks: Track[];
   inputTextDevice: string;
+  time: number;
+  setTime: Dispatch<SetStateAction<number>>;
 }
 
 function ProjectSetting({
@@ -29,18 +32,23 @@ function ProjectSetting({
   selectedTrack,
   tracks,
   inputTextDevice,
+  time,
+  setTime,
 }: ProjectSettingProps) {
   return (
     <div id="project-setting">
-      <div id="setting-box">
-        <input className="project-title" onInput={onTitleInput} type="text" placeholder="프로젝트명" />
-        <RecordDevice onDeviceClick={onDeviceClick} inputTextDevice={inputTextDevice} />
-        <Bpm bpmState={bpmState} onBpmInput={onBpmInput} />
-        <TrackTag onTrackClick={onTrackClick} selectedTrack={selectedTrack} tracks={tracks} />
+      <div id="setting-section">
+        <div id="setting-box">
+          <input className="project-title" onInput={onTitleInput} type="text" placeholder="프로젝트명" />
+          <RecordDevice onDeviceClick={onDeviceClick} inputTextDevice={inputTextDevice} />
+          <Bpm bpmState={bpmState} onBpmInput={onBpmInput} />
+          <TrackTag onTrackClick={onTrackClick} selectedTrack={selectedTrack} tracks={tracks} />
+        </div>
+        <Button type="green" onBtnClick={onBtnClick} width="20rem" marginTop="5rem">
+          프로젝트 생성하기
+        </Button>
       </div>
-      <Button type="green" onBtnClick={onBtnClick} width="20rem" marginTop="5rem">
-        프로젝트 생성하기
-      </Button>
+      <TrackSpace currentTime={time} setCurrentTime={setTime} />
     </div>
   );
 }

--- a/client/src/components/blocks/ProjectSetting/style.scss
+++ b/client/src/components/blocks/ProjectSetting/style.scss
@@ -1,5 +1,11 @@
 #project-setting {
   display: flex;
+  width: 100%;
+  height: 100%;
+}
+
+#setting-section {
+  display: flex;
   flex-direction: column;
   justify-content: space-between;
   align-items: center;

--- a/client/src/components/blocks/TrackSpace/index.tsx
+++ b/client/src/components/blocks/TrackSpace/index.tsx
@@ -1,0 +1,58 @@
+import { DragEvent, useEffect, useRef, useState } from "react";
+import PlayStick from "../PlayStick";
+import "./style.scss";
+
+function TrackSpace({ currentTime, setCurrentTime }: any) {
+  const trackSpaceRef = useRef<HTMLInputElement>(null);
+  const playStickRef = useRef<HTMLDivElement>(null);
+  const [drag, setDrag] = useState(false);
+  const [handleOffset, setHandleOffset] = useState(currentTime);
+
+  const mouseUpHandler = () => {
+    setDrag(false);
+  };
+  const mouseDownHandler = () => {
+    setDrag(true);
+  };
+  const mouseLeaveHandler = () => {
+    setDrag(false);
+  };
+  const dragHandler = (e: DragEvent) => {
+    if (!drag) return;
+    if (e.pageX <= 0) return;
+    const PADDING_LEFT = 80;
+    const HALF_OF_HANDLE_WIDTH = 6;
+    setHandleOffset(
+      e.pageX - (trackSpaceRef.current as HTMLDivElement).offsetLeft - HALF_OF_HANDLE_WIDTH - PADDING_LEFT,
+    );
+  };
+  const dragStartHandler = (e: DragEvent) => {
+    const img = new Image();
+    e.dataTransfer.setDragImage(img, 0, 0);
+  };
+
+  useEffect(() => {
+    setCurrentTime(((handleOffset * 30) / (trackSpaceRef.current as HTMLDivElement).offsetWidth) * 100);
+    // 재생 막대 바 드래그 범위를 TrackSpace 내부로 제한
+    if (handleOffset <= 0 || handleOffset >= (trackSpaceRef.current as HTMLDivElement).offsetWidth - 6 * 16) {
+      setDrag(false);
+    }
+  }, [handleOffset]);
+
+  return (
+    <div
+      id="track-space"
+      draggable="true"
+      onMouseUp={mouseUpHandler}
+      onMouseDown={mouseDownHandler}
+      onMouseLeave={mouseLeaveHandler}
+      onDrag={dragHandler}
+      onDragStart={dragStartHandler}
+      ref={trackSpaceRef}
+    >
+      <PlayStick currentOffset={handleOffset} currentRef={playStickRef} />
+    </div>
+  );
+}
+
+export default TrackSpace;

--- a/client/src/components/blocks/TrackSpace/style.scss
+++ b/client/src/components/blocks/TrackSpace/style.scss
@@ -1,0 +1,6 @@
+#track-space {
+  width: 100%;
+  height: 100%;
+  padding-left: 80px;
+  background-color: transparent;
+}

--- a/client/src/stories/PlayStick.stories.tsx
+++ b/client/src/stories/PlayStick.stories.tsx
@@ -1,0 +1,19 @@
+import { ComponentMeta, ComponentStory } from "@storybook/react";
+
+import PlayStick from "components/blocks/PlayStick";
+
+export default {
+  title: "blocks/PlayStick",
+  component: PlayStick,
+  argTypes: {
+    currentTime: { control: "number" },
+  } as ComponentMeta<typeof PlayStick>,
+};
+
+const Template: ComponentStory<typeof PlayStick> = (args) => <PlayStick {...args} />;
+
+export const Default = Template.bind({});
+Default.args = {
+  maxOffsetX: 1800,
+  minOffsetX: 16,
+};

--- a/client/src/stories/TrackSpace.stories.tsx
+++ b/client/src/stories/TrackSpace.stories.tsx
@@ -1,0 +1,18 @@
+import { ComponentMeta, ComponentStory } from "@storybook/react";
+
+import TrackSpace from "components/blocks/TrackSpace";
+
+export default {
+  title: "blocks/TrackSpace",
+  component: TrackSpace,
+  argTypes: {
+    currentTime: { control: "number" },
+  } as ComponentMeta<typeof TrackSpace>,
+};
+
+const Template: ComponentStory<typeof TrackSpace> = (args) => <TrackSpace {...args} />;
+
+export const Default = Template.bind({});
+Default.args = {
+  currentTime: 0,
+};

--- a/client/src/viewmodel/ProjectItemViewModel.tsx
+++ b/client/src/viewmodel/ProjectItemViewModel.tsx
@@ -60,7 +60,7 @@ function ProjectItemViewModel({ projectId, projectName, trackPreviews, likeCount
   };
 
   return (
-    <NavLink to={`/detailproject?projectId=${projectId}`}>
+    <NavLink to={`/detailProject/${projectId}`}>
       <ProjectItem
         projectId={projectId}
         isLiked={isLikedState}

--- a/client/src/viewmodel/ProjectSettingViewModel.tsx
+++ b/client/src/viewmodel/ProjectSettingViewModel.tsx
@@ -14,6 +14,7 @@ function ProjectSettingViewModel() {
   const [selectedTrack, setSelectedTrack] = useRecoilState(selectedTrackState);
   const [inputTextDevice, setInputTextDevice] = useRecoilState(inputDeviceTextState);
   const [inputDeviceId, setInputDeviceId] = useState("");
+  const [time, setTime] = useState(0);
   const isRecording = useRef(false);
   const navigate = useNavigate();
 
@@ -92,6 +93,8 @@ function ProjectSettingViewModel() {
       selectedTrack={selectedTrack}
       tracks={trackList}
       inputTextDevice={inputTextDevice}
+      time={time}
+      setTime={setTime}
     />
   );
 }


### PR DESCRIPTION
## 구현 기능 
- 재생 막대 바
- ProjectSettingViewModel 라우터 설정
- 재생 막대 바의 props로 time, setTime 전달
- dragEvent를 통해 재생 막대 바 이동 및 setTime 업데이트

## 공유하고 싶은 내용
- 프로젝트 상세페이지의 경우, 프로젝트가 10개가 모두 차있지 않은 상황에 한해서 프로젝트를 수정할 수 있으므로 프로젝트 상세페이지와 수정페이지 모두 ProjectSettingViewModel을 프로젝트 상세에서 사용
- 현재 재생 시간을 나타내는 time, setTime을 ProjectSettingViewModel에 생성 후, 자식 컴포넌트에 props로 전달
  - 오늘 구현한 트랙박스 ProjectSettingViewModel에 삽입 후 scss 수정 필요

Close #300
