### PR TITLE
qa/358: 해상도가 줄어들면 배너와 텍스트가 깨지는 현상 해결

### DIFF
--- a/client/public/index.html
+++ b/client/public/index.html
@@ -47,6 +47,7 @@
     body {
       width: calc(100vw - 12rem);
       max-width: 100%;
+      min-width: 19rem;
       height: calc(100vh - 5rem);
       padding: 5rem 6rem 0;
       margin: 0;

--- a/client/src/components/blocks/NavBar/style.scss
+++ b/client/src/components/blocks/NavBar/style.scss
@@ -35,6 +35,7 @@ header {
     nav > ul {
       display: flex;
       list-style: none;
+      white-space: nowrap;
 
       .signin {
         display: flex;


### PR DESCRIPTION
## 구현 기능 
 해상도가 줄어들면 배너와 텍스트가 깨지는 현상 해결

Close #358 
