### PR TITLE
fix/356: 트랙 아이콘 목록이 프로젝트 컴포넌트 밖으로 오버되는 현상 해결

### DIFF
--- a/client/src/components/atoms/TrackIcon/index.tsx
+++ b/client/src/components/atoms/TrackIcon/index.tsx
@@ -8,7 +8,7 @@ interface TrackIconProps {
 }
 function TrackIcon({ track, style }: TrackIconProps) {
   return (
-    <div id="track-icon" style={style}>
+    <div className="track-icon" style={style}>
       <img src={TrackIconSrc[track]} alt={track} />
     </div>
   );

--- a/client/src/components/atoms/TrackIcon/style.scss
+++ b/client/src/components/atoms/TrackIcon/style.scss
@@ -1,9 +1,9 @@
-#track-icon {
+.track-icon {
   display: flex;
   justify-content: center;
   align-items: center;
-  width: 2.2rem;
-  height: 2.2rem;
+  width: 2rem;
+  height: 2rem;
   position: relative;
   border: solid 2px #242424;
   border-radius: 24px;

--- a/client/src/components/blocks/ProjectItem/style.scss
+++ b/client/src/components/blocks/ProjectItem/style.scss
@@ -4,8 +4,8 @@
   justify-content: space-between;
   align-items: center;
   width: 20vw;
-  min-width: 300px;
-  height:10rem;
+  min-width: 19rem;
+  height: 10rem;
   padding: 1.2rem 1rem;
   margin-top: 24px;
   margin-left: 24px;
@@ -31,15 +31,15 @@
     display: flex;
     justify-content: flex-start;
     align-items: center;
-    width: 120%;
+    width: 100%;
+    height: 2rem;
     position: relative;
-    left: 30px;
   }
 
   hr {
     width: 95%;
     border: 0;
-    border-top: 1px solid  #555;
+    border-top: 1px solid #555;
   }
 
   #item-bottom {


### PR DESCRIPTION
## 구현 기능 
트랙 아이콘 목록이 프로젝트 컴포넌트 밖으로 오버되는 현상 해결

Close #356 
