### PR TITLE
feat/399: 액세스 토큰 만료 시 /reissue 로 액세스 재발급 요청 해결

### DIFF
--- a/client/src/App.tsx
+++ b/client/src/App.tsx
@@ -10,6 +10,7 @@ import CreateProjectPage from "components/pages/CreateProjectPage";
 import ProjectListPage from "components/pages/ProjectListPage";
 import CreateTrackPage from "components/pages/CreateTrackPage";
 import DetailProjectPage from "components/pages/DetailProjectPage";
+import AuthRequired from "components/atoms/Auth/AuthRequired";
 
 function App() {
   return (
@@ -17,13 +18,34 @@ function App() {
       <NavBar />
       <Routes>
         <Route path="/" element={<ProjectListPage />} />
-        <Route path="/create" element={<CreateProjectPage />} />
+        <Route
+          path="/create"
+          element={
+            <AuthRequired>
+              <CreateProjectPage />
+            </AuthRequired>
+          }
+        />
         <Route path="/signin" element={<SignInViewModel />} />
         <Route path="/signup" element={<SignUpViewModel />} />
         <Route path="/auth/redirect/:snsType" element={<RedirectViewModel />} />
         <Route path="/:projectId" element={<DetailProjectPage />} />
-        <Route path="/update/:projectId" element={<ProjectSettingViewModel />} />
-        <Route path="/:projectId/track/new" element={<CreateTrackPage />} />
+        <Route
+          path="/update/:projectId"
+          element={
+            <AuthRequired>
+              <ProjectSettingViewModel />
+            </AuthRequired>
+          }
+        />
+        <Route
+          path="/:projectId/track/new"
+          element={
+            <AuthRequired>
+              <CreateTrackPage />
+            </AuthRequired>
+          }
+        />
       </Routes>
     </BrowserRouter>
   );

--- a/client/src/App.tsx
+++ b/client/src/App.tsx
@@ -5,6 +5,7 @@ import { SignInViewModel } from "viewmodel/SignInViewModel";
 import { SignUpViewModel } from "viewmodel/SignUpViewModel";
 import { RedirectViewModel } from "viewmodel/RedirectViewModel";
 import ProjectSettingViewModel from "viewmodel/CreateProjectViewModel";
+import RouteHandlerViewModel from "viewmodel/RouteHandlerViewModel";
 
 import CreateProjectPage from "components/pages/CreateProjectPage";
 import ProjectListPage from "components/pages/ProjectListPage";
@@ -15,6 +16,7 @@ import AuthRequired from "components/atoms/Auth/AuthRequired";
 function App() {
   return (
     <BrowserRouter>
+      <RouteHandlerViewModel />
       <NavBar />
       <Routes>
         <Route path="/" element={<ProjectListPage />} />

--- a/client/src/components/atoms/Auth/AuthRequired.tsx
+++ b/client/src/components/atoms/Auth/AuthRequired.tsx
@@ -9,7 +9,7 @@ type Props = {
 
 export default function AuthRequired({ children }: Props) {
   const navigate = useNavigate();
-  const { isAuthorized } = useAuth({ reissue: false });
+  const { isAuthorized } = useAuth();
 
   useEffect(() => {
     if (!isAuthorized) {

--- a/client/src/components/atoms/Auth/hooks/useAuth.ts
+++ b/client/src/components/atoms/Auth/hooks/useAuth.ts
@@ -40,8 +40,8 @@ const useAuth = (props?: Props) => {
     isAuthorized: !!accessToken,
     setAuth,
     signOut: () => {
-      API.get("/logout");
       resetAccessToken();
+      API.get("/logout");
     },
   };
 };

--- a/client/src/components/blocks/NavBar/index.tsx
+++ b/client/src/components/blocks/NavBar/index.tsx
@@ -14,7 +14,7 @@ export function NavBar() {
   const LogoImgUrl = `${process.env.PUBLIC_URL}/assets/logo/logo@2x.png`;
   const SignInImgUrl = `${process.env.PUBLIC_URL}/assets/signin/logo@2x.png`;
 
-  const { isAuthorized, signOut } = useAuth({ reissue: false });
+  const { isAuthorized, signOut } = useAuth();
 
   const handleLoginButtonClick = () => {
     if (!isAuthorized) {

--- a/client/src/components/pages/CreateProjectPage/index.jsx
+++ b/client/src/components/pages/CreateProjectPage/index.jsx
@@ -1,14 +1,11 @@
 import "./style.scss";
 import CreateProjectViewModel from "viewmodel/CreateProjectViewModel";
-import AuthRequired from "components/atoms/Auth/AuthRequired";
 
 function CreateProjectPage() {
   return (
-    <AuthRequired>
-      <div id="create-project">
-        <CreateProjectViewModel />
-      </div>
-    </AuthRequired>
+    <div id="create-project">
+      <CreateProjectViewModel />
+    </div>
   );
 }
 

--- a/client/src/model/authModel.ts
+++ b/client/src/model/authModel.ts
@@ -1,32 +1,6 @@
 import { atom } from "recoil";
 
-import tokenStorage from "utils/tokenStorage";
-import { API } from "api/axios";
-import { ACCESS_TOKEN_KEY } from "constants/key";
-
 export const accessTokenAtom = atom<string | null>({
   key: "accessToken",
   default: null,
-  effects_UNSTABLE: [
-    (param) => {
-      const storage = tokenStorage(ACCESS_TOKEN_KEY);
-      const defaultToken = storage.get();
-      const isAuthorized = () => !!defaultToken;
-
-      if (isAuthorized()) {
-        param.setSelf(defaultToken);
-        API.defaults.headers.common.Authorization = `Bearer ${defaultToken}`;
-      }
-
-      param.onSet((newToken, _, isReset) => {
-        if (isReset || !newToken) {
-          storage.remove();
-          return;
-        }
-
-        storage.set(newToken);
-        API.defaults.headers.common.Authorization = `Bearer ${newToken}`;
-      });
-    },
-  ],
 });

--- a/client/src/viewmodel/ProjectItemViewModel.tsx
+++ b/client/src/viewmodel/ProjectItemViewModel.tsx
@@ -14,7 +14,7 @@ function ProjectItemViewModel({ projectId, projectName, trackPreviews, likeCount
   const [isPlaying, setIsPlaying] = useState(false);
   const setModalOpen = useSetRecoilState(modalOpenState);
   const previewPlayerRefs = trackPreviews.map(() => useRef<HTMLMediaElement>(null));
-  const { isAuthorized: isAuthed } = useAuth({ reissue: false });
+  const { isAuthorized: isAuthed } = useAuth();
 
   const previewAction = (ref: RefObject<HTMLMediaElement>, action: string) => {
     return new Promise(() => {

--- a/client/src/viewmodel/RedirectViewModel.tsx
+++ b/client/src/viewmodel/RedirectViewModel.tsx
@@ -18,7 +18,7 @@ export function RedirectViewModel() {
   const code = query.get("code");
   const state = query.get("state");
 
-  const { isAuthorized, setAuth } = useAuth({ reissue: false });
+  const { isAuthorized, setAuth } = useAuth();
 
   useEffect(() => {
     if (isAuthorized) {

--- a/client/src/viewmodel/RouteHandlerViewModel.tsx
+++ b/client/src/viewmodel/RouteHandlerViewModel.tsx
@@ -1,0 +1,31 @@
+import { useEffect } from "react";
+import { useLocation } from "react-router-dom";
+import { useSetRecoilState } from "recoil";
+import { accessTokenAtom } from "model/authModel";
+import tokenStorage from "utils/tokenStorage";
+import { ACCESS_TOKEN_KEY } from "constants/key";
+import { API } from "api/axios";
+
+function RouteHandlerViewModel() {
+  const location = useLocation();
+  const setAccessToken = useSetRecoilState(accessTokenAtom);
+
+  const updateAuth = () => {
+    const storage = tokenStorage(ACCESS_TOKEN_KEY);
+    const accessToken = storage.get();
+    const isAuthed = !!accessToken;
+
+    if (isAuthed) {
+      API.defaults.headers.common.Authorization = `Bearer ${accessToken}`;
+      setAccessToken(accessToken);
+    }
+  };
+
+  useEffect(() => {
+    updateAuth();
+  }, [location.pathname]);
+
+  return <div />;
+}
+
+export default RouteHandlerViewModel;

--- a/client/src/viewmodel/SignUpViewModel.tsx
+++ b/client/src/viewmodel/SignUpViewModel.tsx
@@ -25,7 +25,7 @@ export function SignUpViewModel() {
   const location = useLocation();
   const navigate = useNavigate();
   const [signUp, setSignUp] = useRecoilState(signUpState);
-  const { setAuth } = useAuth({ reissue: false });
+  const { setAuth } = useAuth();
 
   const { authId, email, profileImageUrl, snsType } = location.state as MemberData;
 


### PR DESCRIPTION
<!-- 제목 : {issue 라벨}/{issue 번호}: {이슈 내용} 구현 완료 or ~ {이슈 내용} 작업 완료 -->
## 구현 기능 
<!-- (optional) 해당 pr에서 구현된 기능 소개 -->
- useAuth 훅 리팩토링
- 토큰 재발행 로직을 api interceptor에서 구현
- 페이지 이동 시 로그인 상태 갱신


## 논의하고 싶은 내용 <!--(optional) -->
<!-- 구현된 사항에 대해 논의가 되어야할 내용 설명 (리뷰 시 주목해서 봐줬으면 하는 부분)-->



## 공유하고 싶은 내용 <!--(optional) -->
<!-- 구현하면서 추가된 공유되어야할 사항들(설정 시 필요한 id/pw 라던가) 설명 -->
중복되는 로직이 많은데 일단 구현에 초점을 두었어요ㅎㅎ
커밋별로 보는게 편할거예요!
    
Close #399 <!--issue 번호-->
Close #400 <!--issue 번호-->
